### PR TITLE
fix: set_group_add_request reason 字段错误

### DIFF
--- a/src/onebot11/action/group/SetGroupAddRequest.ts
+++ b/src/onebot11/action/group/SetGroupAddRequest.ts
@@ -12,7 +12,7 @@ const SchemaData = {
     approve: { type: 'boolean' },
     reason: { type: 'string' }
   },
-  required: ['flag', 'approve', 'reson']
+  required: ['flag', 'approve', 'reason']
 } as const satisfies JSONSchema;
 
 type Payload = FromSchema<typeof SchemaData>;


### PR DESCRIPTION
[处理加群请求／邀请](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#set_group_add_request-%E5%A4%84%E7%90%86%E5%8A%A0%E7%BE%A4%E8%AF%B7%E6%B1%82%E9%82%80%E8%AF%B7)

## `set_group_add_request` 处理加群请求／邀请

### 参数

| 字段名 | 数据类型 | 默认值 | 说明 |
| ----- | ------- | ----- | --- |
| `flag` | string | - | 加群请求的 flag（需从上报的数据中获得） |
| `sub_type` 或 `type` | string | - | `add` 或 `invite`，请求类型（需要和上报消息中的 `sub_type` 字段相符） |
| `approve` | boolean | `true` | 是否同意请求／邀请 |
| `reason` | string | 空 | 拒绝理由（仅在拒绝时有效） |