### PR TITLE
fix: `.editorconfig` wrong pair `end_of_line`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
-end_of_line = lf|crlf
+end_of_line = lf
 insert_final_newline = true
 
 # Matches multiple files with brace expansion notation


### PR DESCRIPTION
`end_of_line`:
> Set to lf, cr, or crlf to control how line breaks are represented. The values are case insensitive.

The _or_ is exclusive.

I found that in the existing files, it was almost always LF. So I guess setting to LF is appropriate.

ref: https://spec.editorconfig.org/#supported-pairs