### PR TITLE
对缓存进一步优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 # Build
 *.db
 checkVersion.sh
+bun.lockb


### PR DESCRIPTION
LRUCache 将所有被移除的缓存数据作为事件参数传递给事件处理程序。

在数据库操作部分，优化了读写流程，以确保每个群组至多执行三次数据库操作：

读取：先判断缓存中是否存在用户记录，若不存在则读取数据库。
创建：如果用户记录在数据库中不存在，则新增记录。
修改：如果用户记录在数据库中存在，则进行修改。
即使单个群组内有大量用户，每种操作也只会执行一次。