### PR TITLE
BUG修复

### DIFF
--- a/src/core/src/entities/group.ts
+++ b/src/core/src/entities/group.ts
@@ -52,4 +52,5 @@ export interface GroupMember {
     isRobot: boolean;
     sex?: Sex
     qqLevel?: QQLevel
+    isChangeRole: boolean;
 }

--- a/src/onebot11/action/msg/DeleteMsg.ts
+++ b/src/onebot11/action/msg/DeleteMsg.ts
@@ -7,7 +7,12 @@ import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 const SchemaData = {
   type: 'object',
   properties: {
-    message_id: { type: 'number' },
+    message_id: {
+      oneOf:[
+        { type: 'number' },
+        { type: 'string' }
+      ]
+    }
   },
   required: ['message_id']
 } as const satisfies JSONSchema;
@@ -18,7 +23,7 @@ class DeleteMsg extends BaseAction<Payload, void> {
   actionName = ActionName.DeleteMsg;
   PayloadSchema = SchemaData;
   protected async _handle(payload: Payload) {
-    const msg = await dbUtil.getMsgByShortId(payload.message_id);
+    const msg = await dbUtil.getMsgByShortId(Number(payload.message_id));
     if (msg) {
       await NTQQMsgApi.recallMsg({ peerUid: msg.peerUid, chatType: msg.chatType }, [msg.msgId]);
     }


### PR DESCRIPTION
1.尝试让所有人能收到group_admin事件（菜鸡的歪办法：利用Core.MemberInfoChange标记变化，随后在OB11同名事件里进行post）
2.修复请求API: delete_msg（POST请求网址传参）将负数判定为文本导致无法调用的问题