### PR TITLE
bug修复和标准兼容

### DIFF
--- a/src/onebot11/action/go-cqhttp/GetGroupMsgHistory.ts
+++ b/src/onebot11/action/go-cqhttp/GetGroupMsgHistory.ts
@@ -18,7 +18,7 @@ const SchemaData = {
     message_seq: { type: 'number' },
     count: { type: 'number' }
   },
-  required: ['group_id', 'message_seq', 'count']
+  required: ['group_id', 'count']
 } as const satisfies JSONSchema;
 
 type Payload = FromSchema<typeof SchemaData>;
@@ -31,7 +31,7 @@ export default class GoCQHTTPGetGroupMsgHistory extends BaseAction<Payload, Resp
     if (!group) {
       throw `群${payload.group_id}不存在`;
     }
-    const startMsgId = (await MessageUnique.getMsgIdAndPeerByShortId(payload.message_seq))?.MsgId || '0';
+    const startMsgId = (await MessageUnique.getMsgIdAndPeerByShortId(payload.message_seq || 0))?.MsgId || '0';
     // log("startMsgId", startMsgId)
     const historyResult = (await NTQQMsgApi.getMsgHistory({
       chatType: ChatType.group,

--- a/src/onebot11/action/msg/SendMsg/create-send-elements.ts
+++ b/src/onebot11/action/msg/SendMsg/create-send-elements.ts
@@ -12,7 +12,7 @@ import {
   SignMusicWrapper
 } from '@/core';
 import { getGroupMember } from '@/core/data';
-import { logDebug, logError } from '@/common/utils/log';
+import { logDebug, logError, logWarn } from '@/common/utils/log';
 import { uri2local } from '@/common/utils/file';
 import { ob11Config } from '@/onebot11/config';
 import { RequestUtil } from '@/common/utils/request';
@@ -88,6 +88,10 @@ const _handlers: {
 
   [OB11MessageDataType.reply]: async ({ data: { id } }) => {
     const replyMsgM = MessageUnique.getMsgIdAndPeerByShortId(parseInt(id));
+    if (!replyMsgM) {
+      logWarn('回复消息不存在', id);
+      return undefined;
+    }
     const replyMsg = (await NTQQMsgApi.getMsgsByMsgId(replyMsgM?.Peer!, [replyMsgM?.MsgId!])).msgList[0];
     return replyMsg ?
       SendMsgElementConstructor.reply(replyMsg.msgSeq, replyMsg.msgId, replyMsg.senderUin!, replyMsg.senderUin!) :


### PR DESCRIPTION
**BUG修复**
修复创建reply消息体时向NTQQMsgApi.getMsgsByMsgId提交空值查询会导致QQ崩溃的BUG

**标准兼容**
根据GOCQ标准将获取群历史消息中的msg_seq改为非必要参数，默认为0