### PR TITLE
fix: revert get_friends_with_category return type

### DIFF
--- a/src/core/apis/friend.ts
+++ b/src/core/apis/friend.ts
@@ -54,21 +54,21 @@ export class NTQQFriendApi {
         uids.push(
             ...buddyListV2.flatMap(item => {
                 item.buddyUids.forEach(uid => {
-                    categoryMap.set(uid, { categoryId: item.categoryId, categroyName: item.categroyName });
+                    categoryMap.set(uid, { categoryId: item.categoryId, categoryName: item.categroyName });
                 });
                 return item.buddyUids;
             }));
         const data = await this.core.eventWrapper.callNoListenerEvent<NodeIKernelProfileService['getCoreAndBaseInfo']>(
             'NodeIKernelProfileService/getCoreAndBaseInfo', 5000, 'nodeStore', uids,
         );
-        return Array.from(data).map(([key, value]) => {
-            const category = categoryMap.get(key);
-            return category ? {
-                ...value,
-                categoryId: category.categoryId,
-                categroyName: category.categroyName,
-            } : value;
-        });
+        return buddyListV2.map(category => ({
+            categoryId: category.categoryId,
+            categorySortId: category.categorySortId,
+            categoryName: category.categroyName,
+            categoryMbCount: category.categroyMbCount,
+            onlineCount: category.onlineCount,
+            buddyList: category.buddyUids.map(uid => data.get(uid)!).filter(value => value),
+        }));
     }
 
     async isBuddy(uid: string) {

--- a/src/core/entities/user.ts
+++ b/src/core/entities/user.ts
@@ -176,10 +176,7 @@ export interface SimpleInfo {
     intimate: any | null;
 }
 
-export interface FriendV2 extends SimpleInfo {
-    categoryId?: number;
-    categroyName?: string;
-}
+export type FriendV2 = SimpleInfo;
 
 export interface SelfStatusInfo {
     uid: string;

--- a/src/onebot/action/extends/GetFriendWithCategory.ts
+++ b/src/onebot/action/extends/GetFriendWithCategory.ts
@@ -8,7 +8,10 @@ export class GetFriendWithCategory extends BaseAction<void, any> {
     async _handle(payload: void) {
         if (this.CoreContext.context.basicInfoWrapper.requireMinNTQQBuild('26702')) {
             //全新逻辑
-            return OB11Constructor.friendsV2(await this.CoreContext.apis.FriendApi.getBuddyV2ExWithCate(true));
+            return (await this.CoreContext.apis.FriendApi.getBuddyV2ExWithCate(true)).map(category => ({
+                ...category,
+                buddyList: OB11Constructor.friendsV2(category.buddyList),
+            }));
         } else {
             throw new Error('this ntqq version not support, must be 26702 or later');
         }

--- a/src/onebot/helper/data.ts
+++ b/src/onebot/helper/data.ts
@@ -656,8 +656,6 @@ export class OB11Constructor {
                 remark: friend.coreInfo.nick,
                 sex: sexValue,
                 level: 0,
-                categroyName: friend.categroyName,
-                categoryId: friend.categoryId,
             });
         });
         return data;

--- a/src/onebot/types/entity.ts
+++ b/src/onebot/types/entity.ts
@@ -7,7 +7,7 @@ export interface OB11User {
     age?: number;
     qid?: string;
     login_days?: number;
-    categroyName?: string;
+    categoryName?: string;
     categoryId?: number;
 }
 


### PR DESCRIPTION
将 get_friends_with_category  返回类型改回以前的格式

```
{
        categoryId: number;
        categoryName: string;
        categoryMbCount: number;
        buddyList: [];
}
```

以保留分组顺序和结构，同时修复 category 的 typo