### PR TITLE
%RetString% 增加引号，解决QQ目录包含空格的问题

### DIFF
--- a/launcher/launcher.bat
+++ b/launcher/launcher.bat
@@ -21,7 +21,8 @@ for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\M
 )
 
 :napcat_boot
-for %%a in (%RetString%) do (
+:: %RetString% 增加引号，解决QQ目录包含空格的问题，比如安装在：C:\Program Files\Tencent\QQNT
+for %%a in ("%RetString%") do (
     set "pathWithoutUninstall=%%~dpa"
 )
 


### PR DESCRIPTION
%RetString% 增加引号，解决QQ目录包含空格的问题，比如安装在：C:\Program Files\Tencent\QQNT时，获取不到正确的路径