### PR TITLE
feat: support more types of music cards

### DIFF
--- a/src/core/entities/sign.ts
+++ b/src/core/entities/sign.ts
@@ -1,14 +1,15 @@
 export interface IdMusicSignPostData {
-    type: 'qq' | '163',
+    type: 'qq' | '163' | 'kugou' | 'migu' | 'kuwo',
     id: string | number,
 }
 
 export interface CustomMusicSignPostData {
-    type: 'custom',
+    type: 'qq' | '163' | 'kugou' | 'migu' | 'kuwo' | 'custom',
+    id:undefined,
     url: string,
-    audio: string,
-    title: string,
-    image?: string,
+    audio?: string,
+    title?: string,
+    image: string,
     singer?: string
 }
 

--- a/src/core/entities/sign.ts
+++ b/src/core/entities/sign.ts
@@ -5,7 +5,7 @@ export interface IdMusicSignPostData {
 
 export interface CustomMusicSignPostData {
     type: 'qq' | '163' | 'kugou' | 'migu' | 'kuwo' | 'custom',
-    id:undefined,
+    id: undefined,
     url: string,
     audio?: string,
     title?: string,

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -547,32 +547,28 @@ export class OneBotMsgApi {
 
         [OB11MessageDataType.music]: async ({ data }, context) => {
             // 保留, 直到...找到更好的解决方案
-            if (data.type === 'custom') {
+            if (data.id !== undefined) {
+                if (!['qq', '163', 'kugou', 'kuwo', 'migu'].includes(data.type)) {
+                    this.core.context.logger.logError('音乐卡片type错误, 只支持qq、163、kugou、kuwo、migu，当前type:', data.type);
+                    return undefined;
+                }
+            } else {
+                if (!['qq', '163', 'kugou', 'kuwo', 'migu', 'custom'].includes(data.type)) {
+                    this.core.context.logger.logError('音乐卡片type错误, 只支持qq、163、kugou、kuwo、migu、custom，当前type:', data.type);
+                    return undefined;
+                }
                 if (!data.url) {
                     this.core.context.logger.logError('自定义音卡缺少参数url');
                     return undefined;
                 }
-                if (!data.audio) {
-                    this.core.context.logger.logError('自定义音卡缺少参数audio');
-                    return undefined;
-                }
-                if (!data.title) {
-                    this.core.context.logger.logError('自定义音卡缺少参数title');
-                    return undefined;
-                }
-            } else {
-                if (!['qq', '163'].includes(data.type)) {
-                    this.core.context.logger.logError('音乐卡片type错误, 只支持qq、163、custom，当前type:', data.type);
-                    return undefined;
-                }
-                if (!data.id) {
-                    this.core.context.logger.logError('音乐卡片缺少参数id');
+                if (!data.image) {
+                    this.core.context.logger.logError('自定义音卡缺少参数image');
                     return undefined;
                 }
             }
 
             let postData: IdMusicSignPostData | CustomMusicSignPostData;
-            if (data.type === 'custom' && data.content) {
+            if (data.id === undefined && data.content) {
                 const { content, ...others } = data;
                 postData = { singer: content, ...others };
             } else {


### PR DESCRIPTION
以内置音卡签名接口为标准，扩展可签的音卡类型，这一改动将会使 **type字段为非custom时也能自定义url、image等字段**，这虽然不符合ob11规范，但是内置音卡签名接口允许这种非标调用
![image](https://github.com/user-attachments/assets/5626db30-5f85-4f9c-ab8b-f591e98f9851)
