### PR TITLE
feat: add `friend_poke` OneBot11 API

### DIFF
--- a/src/core/apis/packet.ts
+++ b/src/core/apis/packet.ts
@@ -73,8 +73,8 @@ export class NTQQPacketApi {
         return this.packetSession!.client.sendPacket(cmd, data, rsp);
     }
 
-    async sendPokePacket(group: number, peer: number) {
-        const data = this.packetSession?.packer.packPokePacket(group, peer);
+    async sendPokePacket(peer: number, group?: number) {
+        const data = this.packetSession?.packer.packPokePacket(peer, group);
         await this.sendPacket('OidbSvcTrpcTcp.0xed3_1', data!, false);
     }
 

--- a/src/core/packet/packer.ts
+++ b/src/core/packet/packer.ts
@@ -47,11 +47,11 @@ export class PacketPacker {
         });
     }
 
-    packPokePacket(group: number, peer: number): PacketHexStr {
+    packPokePacket(peer: number, group?: number): PacketHexStr {
         const oidb_0xed3 = new NapProtoMsg(OidbSvcTrpcTcp0XED3_1).encode({
             uin: peer,
             groupUin: group,
-            friendUin: group,
+            friendUin: group ?? peer,
             ext: 0
         });
         return this.toHexStr(this.packOidbPacket(0xed3, 1, oidb_0xed3));

--- a/src/onebot/action/index.ts
+++ b/src/onebot/action/index.ts
@@ -91,6 +91,7 @@ import { GetGroupShutList } from './group/GetGroupShutList';
 import { GetGroupMemberList } from './group/GetGroupMemberList';
 import { GetGroupFileUrl } from "@/onebot/action/file/GetGroupFileUrl";
 import {GetPacketStatus} from "@/onebot/action/packet/GetPacketStatus";
+import {FriendPoke} from "@/onebot/action/user/FriendPoke";
 
 
 export type ActionMap = Map<string, BaseAction<any, any>>;
@@ -189,6 +190,7 @@ export function createActionMap(obContext: NapCatOneBot11Adapter, core: NapCatCo
         new FetchUserProfileLike(obContext, core),
         new GetPacketStatus(obContext, core),
         new GroupPoke(obContext, core),
+        new FriendPoke(obContext, core),
         new GetUserStatus(obContext, core),
         new GetRkey(obContext, core),
         new SetSpecialTittle(obContext, core),

--- a/src/onebot/action/types.ts
+++ b/src/onebot/action/types.ts
@@ -17,6 +17,7 @@ export enum ActionName {
     // 以下为扩展napcat扩展
     Unknown = 'unknown',
     GroupPoke = 'group_poke',
+    FriendPoke = 'friend_poke',
     SharePeer = 'ArkSharePeer',
     ShareGroupEx = 'ArkShareGroup',
     RebootNormal = 'reboot_normal',//无快速登录重新启动

--- a/src/onebot/action/user/FriendPoke.ts
+++ b/src/onebot/action/user/FriendPoke.ts
@@ -1,23 +1,22 @@
 import { ActionName } from '../types';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import {GetPacketStatusDepends} from "@/onebot/action/packet/GetPacketStatus";
-// no_cache get时传字符串
+
 const SchemaData = {
     type: 'object',
     properties: {
-        group_id: { type: ['number', 'string'] },
         user_id: { type: ['number', 'string'] },
     },
-    required: ['group_id', 'user_id'],
+    required: ['user_id'],
 } as const satisfies JSONSchema;
 
 type Payload = FromSchema<typeof SchemaData>;
 
-export class GroupPoke extends GetPacketStatusDepends<Payload, any> {
-    actionName = ActionName.GroupPoke;
+export class FriendPoke extends GetPacketStatusDepends<Payload, any> {
+    actionName = ActionName.FriendPoke;
     payloadSchema = SchemaData;
 
     async _handle(payload: Payload) {
-        await this.core.apis.PacketApi.sendPokePacket(+payload.user_id, +payload.group_id);
+        await this.core.apis.PacketApi.sendPokePacket(+payload.user_id);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

在 OneBot11 框架中添加 `friend_poke` API，支持向好友发送戳一戳动作。重构 `sendPokePacket` 方法以允许可选的群组参数，提高其多功能性。

新功能：
- 在 OneBot11 框架中引入 `friend_poke` API，允许用户向好友发送戳一戳动作。

增强功能：
- 重构 `sendPokePacket` 方法以支持可选的群组参数，提高其在不同用例中的灵活性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add the `friend_poke` API to the OneBot11 framework, enabling poke actions to be sent to friends. Refactor the `sendPokePacket` method to allow optional group parameters, improving its versatility.

New Features:
- Introduce the `friend_poke` API to the OneBot11 framework, allowing users to send poke actions to friends.

Enhancements:
- Refactor the `sendPokePacket` method to support optional group parameters, enhancing its flexibility for different use cases.

</details>