### PR TITLE
修复<get_group_at_all_remain>接口总是返回<Error: atInfo not found>

### DIFF
--- a/src/core/services/NodeIKernelGroupService.ts
+++ b/src/core/services/NodeIKernelGroupService.ts
@@ -233,7 +233,7 @@ export interface NodeIKernelGroupService {
     getGroupStatisticInfo(groupCode: string): unknown;
 
     getGroupRemainAtTimes(groupCode: string): Promise<Omit<GeneralCallResult, 'result'> & {
-        errMsg: string,
+        errCode: number,
         atInfo: {
             canAtAll: boolean
             RemainAtAllCountForUin: number

--- a/src/onebot/action/go-cqhttp/GetGroupAtAllRemain.ts
+++ b/src/onebot/action/go-cqhttp/GetGroupAtAllRemain.ts
@@ -17,8 +17,8 @@ export class GoCQHTTPGetGroupAtAllRemain extends BaseAction<Payload, any> {
 
     async _handle(payload: Payload) {
         const ret = await this.core.apis.GroupApi.getGroupRemainAtTimes(payload.group_id.toString());
-        if (!ret.atInfo || ret.result !== 0) {
-            throw new Error('atInfo not found');
+        if (ret.errCode !== 0) {
+            throw new Error('Not in the group');
         }
         const data = {
             can_at_all: ret.atInfo.canAtAll,


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过更新错误处理逻辑，修复<get_group_at_all_remain>接口总是返回错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the <get_group_at_all_remain> interface always returns an error by updating the error handling logic.

</details>