### PR TITLE
refactor: kill any

### DIFF
--- a/src/common/event.ts
+++ b/src/common/event.ts
@@ -9,6 +9,15 @@ interface InternalMapKey {
     checker: ((...args: any[]) => boolean) | undefined;
 }
 
+type EnsureFunc<T> = T extends (...args: any) => any ? T : never;
+
+type FuncKeys<T> = Extract<
+    {
+        [K in keyof T]: EnsureFunc<T[K]> extends never ? never : K;
+    }[keyof T],
+    string
+>;
+
 export type ListenerClassBase = Record<string, string>;
 
 export class NTEventWrapper {
@@ -43,10 +52,8 @@ export class NTEventWrapper {
 
     createEventFunction<
         Service extends keyof ServiceNamingMapping,
-        ServiceMethod extends Exclude<keyof ServiceNamingMapping[Service], symbol>,
-        // eslint-disable-next-line
-        // @ts-ignore
-        T extends (...args: any) => any = ServiceNamingMapping[Service][ServiceMethod],
+        ServiceMethod extends FuncKeys<ServiceNamingMapping[Service]>,
+        T extends (...args: any) => any = EnsureFunc<ServiceNamingMapping[Service][ServiceMethod]>,
     >(eventName: `${Service}/${ServiceMethod}`): T | undefined {
         const eventNameArr = eventName.split('/');
         type eventType = {
@@ -98,10 +105,8 @@ export class NTEventWrapper {
 
     async callNoListenerEvent<
         Service extends keyof ServiceNamingMapping,
-        ServiceMethod extends Exclude<keyof ServiceNamingMapping[Service], symbol>,
-        // eslint-disable-next-line
-        // @ts-ignore
-        EventType extends (...args: any) => any = ServiceNamingMapping[Service][ServiceMethod],
+        ServiceMethod extends FuncKeys<ServiceNamingMapping[Service]>,
+        EventType extends (...args: any) => any = EnsureFunc<ServiceNamingMapping[Service][ServiceMethod]>,
     >(
         serviceAndMethod: `${Service}/${ServiceMethod}`,
         ...args: Parameters<EventType>
@@ -111,10 +116,8 @@ export class NTEventWrapper {
 
     async registerListen<
         Listener extends keyof ListenerNamingMapping,
-        ListenerMethod extends Exclude<keyof ListenerNamingMapping[Listener], symbol>,
-        // eslint-disable-next-line
-        // @ts-ignore
-        ListenerType extends (...args: any) => any = ListenerNamingMapping[Listener][ListenerMethod],
+        ListenerMethod extends FuncKeys<ListenerNamingMapping[Listener]>,
+        ListenerType extends (...args: any) => any = EnsureFunc<ListenerNamingMapping[Listener][ListenerMethod]>,
     >(
         listenerAndMethod: `${Listener}/${ListenerMethod}`,
         waitTimes = 1,
@@ -164,15 +167,11 @@ export class NTEventWrapper {
 
     async callNormalEventV2<
         Service extends keyof ServiceNamingMapping,
-        ServiceMethod extends Exclude<keyof ServiceNamingMapping[Service], symbol>,
+        ServiceMethod extends FuncKeys<ServiceNamingMapping[Service]>,
         Listener extends keyof ListenerNamingMapping,
-        ListenerMethod extends Exclude<keyof ListenerNamingMapping[Listener], symbol>,
-        // eslint-disable-next-line
-        // @ts-ignore
-        EventType extends (...args: any) => any = ServiceNamingMapping[Service][ServiceMethod],
-        // eslint-disable-next-line
-        // @ts-ignore
-        ListenerType extends (...args: any) => any = ListenerNamingMapping[Listener][ListenerMethod]
+        ListenerMethod extends FuncKeys<ListenerNamingMapping[Listener]>,
+        EventType extends (...args: any) => any = EnsureFunc<ServiceNamingMapping[Service][ServiceMethod]>,
+        ListenerType extends (...args: any) => any = EnsureFunc<ListenerNamingMapping[Listener][ListenerMethod]>
     >(
         serviceAndMethod: `${Service}/${ServiceMethod}`,
         listenerAndMethod: `${Listener}/${ListenerMethod}`,

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -52,7 +52,7 @@ export class FileNapCatOneBotUUID {
         const [, , chatType, peerUid, modelId, fileId, fileUUID = undefined] = data;
         return {
             peer: {
-                chatType: chatType as any,
+                chatType: +chatType,
                 peerUid: peerUid,
             },
             modelId,
@@ -89,7 +89,7 @@ export class FileNapCatOneBotUUID {
         const [, , chatType, peerUid, msgId, elementId, fileUUID = undefined] = data;
         return {
             peer: {
-                chatType: chatType as any,
+                chatType: +chatType,
                 peerUid: peerUid,
             },
             msgId,

--- a/src/common/message-unique.ts
+++ b/src/common/message-unique.ts
@@ -23,10 +23,10 @@ export class LimitedHashTable<K, V> {
         }
         while (this.keyToValue.size > this.maxSize || this.valueToKey.size > this.maxSize) {
             const oldestKey = this.keyToValue.keys().next().value;
-            // @ts-ignore
-            this.valueToKey.delete(this.keyToValue.get(oldestKey)!);
-            // @ts-ignore
-            this.keyToValue.delete(oldestKey);
+            if (oldestKey !== undefined) {
+                this.valueToKey.delete(this.keyToValue.get(oldestKey) as V);
+                this.keyToValue.delete(oldestKey);
+            }
         }
     }
 

--- a/src/core/apis/packet.ts
+++ b/src/core/apis/packet.ts
@@ -191,7 +191,7 @@ export class NTQQPacketApi {
     async sendMiniAppShareInfoReq(param: MiniAppReqParams) {
         const data = this.packetSession?.packer.packMiniAppAdaptShareInfo(param);
         const ret = await this.sendPacket("LightAppSvc.mini_app_share.AdaptShareInfo", data!, true);
-        const body = new NapProtoMsg(MiniAppAdaptShareInfoResp).decode(Buffer.from(ret.hex_data, 'hex'))
+        const body = new NapProtoMsg(MiniAppAdaptShareInfoResp).decode(Buffer.from(ret.hex_data, 'hex'));
         return JSON.parse(body.content.jsonContent) as MiniAppRawData;
     }
 }

--- a/src/core/entities/msg.ts
+++ b/src/core/entities/msg.ts
@@ -64,7 +64,7 @@ type ElementFullBase = Omit<MessageElement, 'elementType' | 'elementId' | 'extBu
 
 type ElementBase<
     K extends keyof ElementFullBase,
-    S extends Partial<{ [P in K]: keyof NonNullable<ElementFullBase[P]> | Array<keyof NonNullable<ElementFullBase[P]>> }> = {}
+    S extends Partial<{ [P in K]: keyof NonNullable<ElementFullBase[P]> | Array<keyof NonNullable<ElementFullBase[P]>> }> = object
 > = {
     [P in K]:
     S[P] extends Array<infer U>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -100,7 +100,7 @@ export class NapCatCore {
         if (!fs.existsSync(this.NapCatTempPath)) {
             fs.mkdirSync(this.NapCatTempPath, { recursive: true });
         }
-       
+
         this.initNapCatCoreListeners().then().catch(this.context.logger.logError.bind(this.context.logger));
 
         this.context.logger.setFileLogEnabled(
@@ -140,7 +140,7 @@ export class NapCatCore {
         };
         //await sleep(2500);
         this.context.session.getMsgService().addKernelMsgListener(
-            proxiedListenerOf(msgListener, this.context.logger) as any,
+            proxiedListenerOf(msgListener, this.context.logger),
         );
 
         const profileListener = new NodeIKernelProfileListener();
@@ -236,7 +236,7 @@ export class NapCatCore {
             }
         };
         this.context.session.getGroupService().addKernelGroupListener(
-            proxiedListenerOf(groupListener, this.context.logger) as any,
+            proxiedListenerOf(groupListener, this.context.logger),
         );
     }
 
@@ -276,7 +276,7 @@ export async function genSessionConfig(
         d2: '',
         d2Key: '',
         machineId: '',
-        platform: systemPlatform,  // 3是Windows? 
+        platform: systemPlatform,  // 3是Windows?
         platVer: systemVersion,  // 系统版本号, 应该可以固定
         appid: QQVersionAppid,
         rdeliveryConfig: {

--- a/src/core/packet/helper/miniAppHelper.ts
+++ b/src/core/packet/helper/miniAppHelper.ts
@@ -38,7 +38,7 @@ export abstract class MiniAppInfo {
             });
             MiniAppInfo.appMap.set("bili", this);
         }
-    }
+    };
 
     static WeiBo = new class extends MiniAppInfo {
         constructor() {
@@ -56,7 +56,7 @@ export abstract class MiniAppInfo {
             });
             MiniAppInfo.appMap.set("weibo", this);
         }
-    }
+    };
 }
 
 export class MiniAppInfoHelper {

--- a/src/core/packet/packer.ts
+++ b/src/core/packet/packer.ts
@@ -742,6 +742,6 @@ export class PacketPacker {
                     }
                 }
             )
-        )
+        );
     }
 }

--- a/src/core/packet/proto/NapProto.ts
+++ b/src/core/packet/proto/NapProto.ts
@@ -61,35 +61,35 @@ export function ProtoField(no: number, type: ScalarType | (() => ProtoMessageTyp
     }
 }
 
-type ProtoFieldReturnType<T extends unknown, E extends boolean> = NonNullable<T> extends ScalarProtoFieldType<infer S, infer O, infer R>
+type ProtoFieldReturnType<T, E extends boolean> = NonNullable<T> extends ScalarProtoFieldType<infer S, infer O, infer R>
     ? ScalarTypeToTsType<S>
     : T extends NonNullable<MessageProtoFieldType<infer S, infer O, infer R>>
     ? NonNullable<NapProtoStructType<ReturnType<S>, E>>
     : never;
 
-type RequiredFieldsBaseType<T extends unknown, E extends boolean> = {
+type RequiredFieldsBaseType<T, E extends boolean> = {
     [K in keyof T as T[K] extends { optional: true } ? never : LowerCamelCase<K & string>]:
     T[K] extends { repeat: true }
     ? ProtoFieldReturnType<T[K], E>[]
     : ProtoFieldReturnType<T[K], E>
 }
 
-type OptionalFieldsBaseType<T extends unknown, E extends boolean> = {
+type OptionalFieldsBaseType<T, E extends boolean> = {
     [K in keyof T as T[K] extends { optional: true } ? LowerCamelCase<K & string> : never]?:
     T[K] extends { repeat: true }
     ? ProtoFieldReturnType<T[K], E>[]
     : ProtoFieldReturnType<T[K], E>
 }
 
-type RequiredFieldsType<T extends unknown, E extends boolean> = E extends true ? Partial<RequiredFieldsBaseType<T, E>> : RequiredFieldsBaseType<T, E>;
+type RequiredFieldsType<T, E extends boolean> = E extends true ? Partial<RequiredFieldsBaseType<T, E>> : RequiredFieldsBaseType<T, E>;
 
-type OptionalFieldsType<T extends unknown, E extends boolean> = E extends true ? Partial<OptionalFieldsBaseType<T, E>> : OptionalFieldsBaseType<T, E>;
+type OptionalFieldsType<T, E extends boolean> = E extends true ? Partial<OptionalFieldsBaseType<T, E>> : OptionalFieldsBaseType<T, E>;
 
-type NapProtoStructType<T extends unknown, E extends boolean> = RequiredFieldsType<T, E> & OptionalFieldsType<T, E>;
+type NapProtoStructType<T, E extends boolean> = RequiredFieldsType<T, E> & OptionalFieldsType<T, E>;
 
-export type NapProtoEncodeStructType<T extends unknown> = NapProtoStructType<T, true>;
+export type NapProtoEncodeStructType<T> = NapProtoStructType<T, true>;
 
-export type NapProtoDecodeStructType<T extends unknown> = NapProtoStructType<T, false>;
+export type NapProtoDecodeStructType<T> = NapProtoStructType<T, false>;
 
 const NapProtoMsgCache = new Map<ProtoMessageType, MessageType<NapProtoStructType<ProtoMessageType, boolean>>>();
 

--- a/src/core/services/NodeIKernelGroupService.ts
+++ b/src/core/services/NodeIKernelGroupService.ts
@@ -12,13 +12,13 @@ import {
 import { GeneralCallResult } from '@/core/services/common';
 
 export interface NodeIKernelGroupService {
-    // ---> 
+    // --->
     // 待启用 For Next Version 3.2.0
     // isTroopMember ? 0 : 111
     getGroupMemberMaxNum(groupCode: string, serviceType: number): Promise<unknown>;
 
     getAllGroupPrivilegeFlag(troopUinList: string[], serviceType: number): Promise<unknown>;
-    // <--- 
+    // <---
     getGroupExt0xEF0Info(enableGroupCodes: string[], bannedGroupCodes: string[], filter: GroupExt0xEF0InfoFilter, forceFetch: boolean):
         Promise<GeneralCallResult & { result: { groupExtInfos: Map<string, any> } }>;
 
@@ -111,7 +111,7 @@ export interface NodeIKernelGroupService {
         }
     }>;
 
-    setHeader(uid: string, path: string): unknown;
+    setHeader(uid: string, path: string): Promise<GeneralCallResult>;
 
     addKernelGroupListener(listener: NodeIKernelGroupListener): number;
 

--- a/src/framework/napcat.ts
+++ b/src/framework/napcat.ts
@@ -41,7 +41,7 @@ export async function NCoreInitFramework(
                 online: true,
             });
         };
-        loginService.addKernelLoginListener(proxiedListenerOf(loginListener, logger) as any);
+        loginService.addKernelLoginListener(proxiedListenerOf(loginListener, logger));
     });
     // 过早进入会导致addKernelMsgListener等Listener添加失败
     // await sleep(2500);

--- a/src/onebot/action/extends/GetMiniAppArk.ts
+++ b/src/onebot/action/extends/GetMiniAppArk.ts
@@ -1,8 +1,8 @@
-import {ActionName} from '../types';
-import {FromSchema, JSONSchema} from 'json-schema-to-ts';
-import {GetPacketStatusDepends} from "@/onebot/action/packet/GetPacketStatus";
-import {MiniAppData, MiniAppRawData, MiniAppReqCustomParams, MiniAppReqParams} from "@/core/packet/entities/miniApp";
-import {MiniAppInfo, MiniAppInfoHelper} from "@/core/packet/helper/miniAppHelper";
+import { ActionName } from '../types';
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { GetPacketStatusDepends } from "@/onebot/action/packet/GetPacketStatus";
+import { MiniAppData, MiniAppRawData, MiniAppReqCustomParams, MiniAppReqParams } from "@/core/packet/entities/miniApp";
+import { MiniAppInfo, MiniAppInfoHelper } from "@/core/packet/helper/miniAppHelper";
 
 const SchemaData = {
     type: 'object',
@@ -11,21 +11,21 @@ const SchemaData = {
             type: 'string',
             enum: ['bili', 'weibo']
         },
-        title: {type: 'string'},
-        desc: {type: 'string'},
-        picUrl: {type: 'string'},
-        jumpUrl: {type: 'string'},
-        iconUrl: {type: 'string'},
-        sdkId: {type: 'string'},
-        appId: {type: 'string'},
-        scene: {type: ['number', 'string']},
-        templateType: {type: ['number', 'string']},
-        businessType: {type: ['number', 'string']},
-        verType: {type: ['number', 'string']},
-        shareType: {type: ['number', 'string']},
-        versionId: {type: 'string'},
-        withShareTicket: {type: ['number', 'string']},
-        rawArkData: {type: ['boolean', 'string']}
+        title: { type: 'string' },
+        desc: { type: 'string' },
+        picUrl: { type: 'string' },
+        jumpUrl: { type: 'string' },
+        iconUrl: { type: 'string' },
+        sdkId: { type: 'string' },
+        appId: { type: 'string' },
+        scene: { type: ['number', 'string'] },
+        templateType: { type: ['number', 'string'] },
+        businessType: { type: ['number', 'string'] },
+        verType: { type: ['number', 'string'] },
+        shareType: { type: ['number', 'string'] },
+        versionId: { type: 'string' },
+        withShareTicket: { type: ['number', 'string'] },
+        rawArkData: { type: ['boolean', 'string'] }
     },
     oneOf: [
         {
@@ -75,11 +75,11 @@ export class GetMiniAppArk extends GetPacketStatusDepends<Payload, {
                     versionId: versionId,
                     withShareTicket: +withShareTicket
                 }
-            )
+            );
         }
         const arkData = await this.core.apis.PacketApi.sendMiniAppShareInfoReq(reqParam);
         return {
-            data: Boolean(payload.rawArkData) ? arkData : MiniAppInfoHelper.RawToSend(arkData)
-        }
+            data: payload.rawArkData ? arkData : MiniAppInfoHelper.RawToSend(arkData)
+        };
     }
 }

--- a/src/onebot/action/extends/SetQQAvatar.ts
+++ b/src/onebot/action/extends/SetQQAvatar.ts
@@ -38,11 +38,10 @@ export default class SetAvatar extends BaseAction<Payload, null> {
                 throw `头像${payload.file}设置失败,api无返回`;
             }
             // log(`头像设置返回：${JSON.stringify(ret)}`)
-            // @ts-ignore
-            if (ret['result'] == 1004022) {
+            if (ret.result as number == 1004022) {
                 throw `头像${payload.file}设置失败，文件可能不是图片格式`;
-            } else if (ret['result'] != 0) {
-                throw `头像${payload.file}设置失败,未知的错误,${ret['result']}:${ret['errMsg']}`;
+            } else if (ret.result != 0) {
+                throw `头像${payload.file}设置失败,未知的错误,${ret.result}:${ret.errMsg}`;
             }
         } else {
             fs.unlink(path, () => { });

--- a/src/onebot/action/go-cqhttp/SetGroupPortrait.ts
+++ b/src/onebot/action/go-cqhttp/SetGroupPortrait.ts
@@ -31,15 +31,15 @@ export default class SetGroupPortrait extends BaseAction<Payload, any> {
         }
         if (path) {
             await checkFileReceived(path, 5000); // 文件不存在QQ会崩溃，需要提前判断
-            const ret = await this.core.apis.GroupApi.setGroupAvatar(payload.group_id.toString(), path) as any;
+            const ret = await this.core.apis.GroupApi.setGroupAvatar(payload.group_id.toString(), path);
             fs.unlink(path, () => { });
             if (!ret) {
                 throw `头像${payload.file}设置失败,api无返回`;
             }
-            if (ret['result'] == 1004022) {
+            if (ret.result as number == 1004022) {
                 throw `头像${payload.file}设置失败，文件可能不是图片格式或权限不足`;
-            } else if (ret['result'] != 0) {
-                throw `头像${payload.file}设置失败,未知的错误,${ret['result']}:${ret['errMsg']}`;
+            } else if (ret.result != 0) {
+                throw `头像${payload.file}设置失败,未知的错误,${ret.result}:${ret.errMsg}`;
             }
             return ret;
         } else {

--- a/src/onebot/action/msg/SendMsg.ts
+++ b/src/onebot/action/msg/SendMsg.ts
@@ -236,12 +236,11 @@ export class SendMsg extends BaseAction<OB11PostSendMsg, ReturnDataType> {
         message: RawMessage | null,
         res_id?: string
     }> {
-        let returnMsg: RawMessage | undefined, res_id: string | undefined;
         const uploadReturnData = await this.uploadForwardedNodesPacket(msgPeer, messageNodes, source, news, summary, prompt);
-        res_id = uploadReturnData?.res_id;
+        const res_id = uploadReturnData?.res_id;
         const finallySendElements = uploadReturnData?.finallySendElements;
         if (!finallySendElements) throw Error('转发消息失败，生成节点为空');
-        returnMsg = await this.obContext.apis.MsgApi.sendMsgWithOb11UniqueId(msgPeer, [finallySendElements], [], true).catch(_ => undefined);
+        const returnMsg = await this.obContext.apis.MsgApi.sendMsgWithOb11UniqueId(msgPeer, [finallySendElements], [], true).catch(_ => undefined);
         return { message: returnMsg ?? null, res_id };
     }
 

--- a/src/onebot/action/msg/SendMsg.ts
+++ b/src/onebot/action/msg/SendMsg.ts
@@ -276,7 +276,6 @@ export class SendMsg extends BaseAction<OB11PostSendMsg, ReturnDataType> {
                             logger.logError.bind(this.core.context.logger)('子消息中包含非node消息 跳过不合法部分');
                             continue;
                         }
-                        // @ts-ignore
                         const nodeMsg = await this.handleForwardedNodes(selfPeer, OB11Data.filter(e => e.type === OB11MessageDataType.node));
                         if (nodeMsg) {
                             nodeMsgIds.push(nodeMsg.message!.msgId);

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -327,11 +327,11 @@ export class OneBotMsgApi {
         },
 
         multiForwardMsgElement: async (_, msg) => {
-            const message_data: OB11MessageForward = {
-                data: {} as any,
-                type: OB11MessageDataType.forward,
-            };
-            message_data.data.id = msg.msgId;
+            // const message_data: OB11MessageForward = {
+            //     data: {} as any,
+            //     type: OB11MessageDataType.forward,
+            // };
+            // message_data.data.id = msg.msgId;
             const parentMsgPeer = msg.parentMsgPeer ?? {
                 chatType: msg.chatType,
                 guildId: '',

--- a/src/onebot/cqcode.ts
+++ b/src/onebot/cqcode.ts
@@ -68,13 +68,13 @@ export function encodeCQCode(data: OB11MessageData) {
 
     let result = '[CQ:' + data.type;
     for (const name in data.data) {
-        const value = (data.data as any)[name];
+        const value = (data.data as Record<string, unknown>)[name];
         if (value === undefined) {
             continue;
         }
         try {
-            const text = value.toString();
-            result += `,${name}=${CQCodeEscape(text)}`;
+            const text = value?.toString();
+            if (text) result += `,${name}=${CQCodeEscape(text)}`;
         } catch (error) {
             // If it can't be converted, skip this name-value pair
         }

--- a/src/onebot/index.ts
+++ b/src/onebot/index.ts
@@ -341,7 +341,7 @@ export class NapCatOneBot11Adapter {
         };
 
         this.context.session.getMsgService().addKernelMsgListener(
-            proxiedListenerOf(msgListener, this.context.logger) as any,
+            proxiedListenerOf(msgListener, this.context.logger),
         );
     }
 
@@ -370,7 +370,7 @@ export class NapCatOneBot11Adapter {
         };
 
         this.context.session.getBuddyService().addKernelBuddyListener(
-            proxiedListenerOf(buddyListener, this.context.logger) as any,
+            proxiedListenerOf(buddyListener, this.context.logger),
         );
     }
 

--- a/src/onebot/network/passive-http.ts
+++ b/src/onebot/network/passive-http.ts
@@ -64,9 +64,9 @@ export class OB11PassiveHttpAdapter implements IOB11NetworkAdapter {
         });
 
         this.app.use((req, res, next) => this.authorize(this.token, req, res, next));
-        // @ts-ignore
-        this.app.use((req, res) => this.handleRequest(req, res));
-
+        this.app.use(async (req, res, _) => {
+            await this.handleRequest(req, res);
+        });
         this.server.listen(this.port, () => {
             this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Start On Port ${this.port}`);
         });

--- a/src/shell/napcat.ts
+++ b/src/shell/napcat.ts
@@ -165,7 +165,7 @@ export async function NCoreInitShell() {
             logger.logError.bind(logger)('[Core] [Login] Login Error , ErrInfo: ', args);
         };
 
-        loginService.addKernelLoginListener(proxiedListenerOf(loginListener, logger) as any);
+        loginService.addKernelLoginListener(proxiedListenerOf(loginListener, logger));
         const isConnect = loginService.connect();
         if (!isConnect) {
             logger.logError.bind(logger)('核心登录服务连接失败!');


### PR DESCRIPTION
## Summary by Sourcery

重构代码库以消除对 'any' 类型的使用，替换为更具体和类型安全的替代方案。这包括对 ProtoFieldReturnType、事件处理和消息处理的类型定义的改进，增强了整体代码的清晰度和安全性。

增强功能：
- 重构类型定义以去除 'any' 的使用，并替换为更具体的类型，提高类型安全性和代码清晰度。
- 通过去除 'unknown' 并使用更精确的类型定义，改进 ProtoFieldReturnType 和相关类型中可选和必需字段的处理。
- 通过引入实用类型 EnsureFunc 和 FuncKeys 来增强事件处理机制，以确保仅使用函数键，提高类型安全性。
- 重构消息处理逻辑，去除不必要的类型断言，并通过使用更具体的类型定义来提高类型安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the codebase to eliminate the use of 'any' type, replacing it with more specific and type-safe alternatives. This includes improvements in type definitions for ProtoFieldReturnType, event handling, and message processing, enhancing overall code clarity and safety.

Enhancements:
- Refactor type definitions to remove the use of 'any' and replace it with more specific types, improving type safety and code clarity.
- Improve the handling of optional and required fields in ProtoFieldReturnType and related types by removing 'unknown' and using more precise type definitions.
- Enhance the event handling mechanism by introducing utility types EnsureFunc and FuncKeys to ensure only function keys are used, improving type safety.
- Refactor the message handling logic to remove unnecessary type assertions and improve type safety by using more specific type definitions.

</details>