### PR TITLE
fix:修正换行符转换问题

### DIFF
--- a/src/onebot/network/active-websocket.ts
+++ b/src/onebot/network/active-websocket.ts
@@ -133,7 +133,7 @@ export class OB11ActiveWebSocketAdapter implements IOB11NetworkAdapter {
         let echo = undefined;
 
         try {
-            receiveData = JSON.parse(message.toString());
+            receiveData = JSON.parse(message.toString().replace(/\r?\n|\r/g, '\\n'));
             echo = receiveData.echo;
             this.logger.logDebug('[OneBot] [WebSocket Client] 收到正向Websocket消息', receiveData);
         } catch (e) {


### PR DESCRIPTION
修正一个换行符转换问题

## Summary by Sourcery

错误修复：
- 通过将换行符替换为 '\n'，修复了 WebSocket 消息处理中的换行符转换问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix an issue with newline character conversion in WebSocket message handling by replacing newline characters with '\n'.

</details>