### PR TITLE
fix: 在处理 file uri 时可能会意外忽略 fragment 段

### DIFF
--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -215,7 +215,7 @@ export async function checkUriType(Uri: string) {
         }
         if (uri.startsWith('file://')) {
             let filePath: string;
-            const pathname = decodeURIComponent(new URL(uri).pathname);
+            const pathname = decodeURIComponent(new URL(uri).pathname + new URL(uri).hash);
             if (process.platform === 'win32') {
                 filePath = pathname.slice(1);
             } else {


### PR DESCRIPTION
在处理类似 ```C:\\test\\test#1.txt``` 时 ```#1.txt``` 由于为 url fragment 而被意外截断