### PR TITLE
perf: avoid silk encoding blocking the main event loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
   },
   "dependencies": {
     "express": "^5.0.0",
+    "fluent-ffmpeg": "^2.1.2",
+    "qrcode-terminal": "^0.12.0",
     "silk-wasm": "^3.6.1",
     "ws": "^8.18.0",
-    "qrcode-terminal": "^0.12.0",
-    "fluent-ffmpeg": "^2.1.2"
+    "piscina": "^4.7.0"
   }
 }

--- a/src/common/audio-worker.ts
+++ b/src/common/audio-worker.ts
@@ -1,0 +1,9 @@
+import { encode } from "silk-wasm";
+
+export interface EncodeArgs {
+    input: ArrayBufferView | ArrayBuffer
+    sampleRate: number
+}
+export default async ({ input, sampleRate }: EncodeArgs) => {
+    return await encode(input, sampleRate);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,14 @@ import { defineConfig, PluginOption, UserConfig } from 'vite';
 import { resolve } from 'path';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { builtinModules } from 'module';
-//依赖排除
-const external = ['silk-wasm', 'ws', 'express', 'qrcode-terminal', 'fluent-ffmpeg'];
+
+const external = ['silk-wasm', 'ws', 'express', 'qrcode-terminal', 'fluent-ffmpeg', 'piscina'];
 const nodeModules = [...builtinModules, builtinModules.map(m => `node:${m}`)].flat();
+
 function genCpModule(module: string) {
     return { src: `./node_modules/${module}`, dest: `dist/node_modules/${module}`, flatten: false };
 }
+
 let startScripts: string[] | undefined = undefined;
 if (process.env.NAPCAT_BUILDSYS == 'linux') {
     startScripts = [];
@@ -17,6 +19,7 @@ if (process.env.NAPCAT_BUILDSYS == 'linux') {
 } else {
     startScripts = ['./script/KillQQ.bat'];
 }
+
 const FrameworkBaseConfigPlugin: PluginOption[] = [
     cp({
         targets: [
@@ -66,9 +69,12 @@ const ShellBaseConfig = () => defineConfig({
         target: 'esnext',
         minify: false,
         lib: {
-            entry: 'src/shell/napcat.ts',
+            entry: {
+                'napcat': 'src/shell/napcat.ts',
+                'audio-worker': 'src/common/audio-worker.ts',
+            },
             formats: ['es'],
-            fileName: () => 'napcat.mjs',
+            fileName: (_, entryName) => `${entryName}.mjs`,
         },
         rollupOptions: {
             external: [...nodeModules, ...external],
@@ -90,9 +96,12 @@ const FrameworkBaseConfig = () => defineConfig({
         target: 'esnext',
         minify: false,
         lib: {
-            entry: 'src/framework/napcat.ts',
+            entry: {
+                'napcat': 'src/framework/napcat.ts',
+                'audio-worker': 'src/common/audio-worker.ts',
+            },
             formats: ['es'],
-            fileName: () => 'napcat.mjs',
+            fileName: (_, entryName) => `${entryName}.mjs`,
         },
         rollupOptions: {
             external: [...nodeModules, ...external],


### PR DESCRIPTION
## Summary by Sourcery

通过使用 Piscina 将 silk 编码卸载到工作线程，提高性能，防止主事件循环阻塞。更新 Vite 构建配置以处理新的工作线程入口点。

增强功能：
- 利用 Piscina 库将 silk 编码卸载到工作线程，防止主事件循环阻塞。

构建：
- 更新 Vite 配置以包含 'audio-worker' 作为单独的入口点，并调整输出文件命名约定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve performance by offloading silk encoding to a worker thread using Piscina, preventing main event loop blocking. Update Vite build configuration to handle new worker entry point.

Enhancements:
- Utilize the Piscina library to offload silk encoding to a worker thread, preventing blocking of the main event loop.

Build:
- Update Vite configuration to include 'audio-worker' as a separate entry point and adjust the output file naming convention.

</details>