### PR TITLE
fix: 允许 SetMsgEmojiLike set 参数传递boolean

### DIFF
--- a/src/onebot/action/msg/SetMsgEmojiLike.ts
+++ b/src/onebot/action/msg/SetMsgEmojiLike.ts
@@ -38,7 +38,11 @@ export class SetMsgEmojiLike extends OneBotAction<Payload, any> {
             msg.Peer,
             msgData[0].msgSeq,
             payload.emoji_id.toString(),
-            typeof payload.set === 'string' ? payload.set === 'true' : !!payload.set
+            typeof payload.set === 'boolean'
+                ? payload.set
+                : (typeof payload.set === 'string'
+                    ? payload.set === 'true'
+                    : !!payload.set)
         );
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复 SetMsgEmojiLike 函数以正确处理 'set' 参数的布尔值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the SetMsgEmojiLike function to correctly handle boolean values for the 'set' parameter.

</details>