### PR TITLE
feat: #538

### DIFF
--- a/napcat.webui/src/pages/OtherConfig.vue
+++ b/napcat.webui/src/pages/OtherConfig.vue
@@ -11,6 +11,9 @@
                 <t-form-item label="启用本地文件到URL" name="enableLocalFile2Url" class="form-item">
                     <t-switch v-model="otherConfig.enableLocalFile2Url" />
                 </t-form-item>
+                <t-form-item label="启用上报解析合并消息" name="parseMultMsg" class="form-item">
+                    <t-switch v-model="otherConfig.parseMultMsg" />
+                </t-form-item>
             </t-form>
             <div class="button-container">
                 <t-button @click="saveConfig">保存</t-button>
@@ -28,6 +31,7 @@ import { QQLoginManager } from '@/backend/shell';
 const otherConfig = ref<Partial<OneBotConfig>>({
     musicSignUrl: '',
     enableLocalFile2Url: false,
+    parseMultMsg: true
 });
 
 const getOB11Config = async (): Promise<OneBotConfig | undefined> => {
@@ -68,6 +72,7 @@ const saveConfig = async () => {
         if (userConfig) {
             userConfig.musicSignUrl = otherConfig.value.musicSignUrl || '';
             userConfig.enableLocalFile2Url = otherConfig.value.enableLocalFile2Url ?? false;
+            userConfig.parseMultMsg = otherConfig.value.parseMultMsg ?? true;
             const success = await setOB11Config(userConfig);
             if (success) {
                 MessagePlugin.success('配置保存成功');

--- a/src/onebot/action/go-cqhttp/GetForwardMsg.ts
+++ b/src/onebot/action/go-cqhttp/GetForwardMsg.ts
@@ -41,7 +41,7 @@ export class GoCQHTTPGetForwardMsgAction extends OneBotAction<Payload, any> {
             for (const msgdata of message.message) {
                 if ((msgdata as OB11MessageData).type === OB11MessageDataType.forward) {
                     const newNode = this.createTemplateNode(message);
-                    newNode.data.message = await this.parseForward((msgdata as OB11MessageForward).data.content);
+                    newNode.data.message = await this.parseForward((msgdata as OB11MessageForward).data.content ?? []);
 
                     templateNode.data.message.push(newNode);
                 } else {

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -19,7 +19,7 @@ import {
     FaceType,
 } from '@/core';
 import faceConfig from '@/core/external/face_config.json';
-import { NapCatOneBot11Adapter, OB11Message, OB11MessageData, OB11MessageDataType, OB11MessageFileBase, } from '@/onebot';
+import { NapCatOneBot11Adapter, OB11Message, OB11MessageData, OB11MessageDataType, OB11MessageFileBase, OB11MessageForward, } from '@/onebot';
 import { OB11Construct } from '@/onebot/helper/data';
 import { EventType } from '@/onebot/event/OneBotEvent';
 import { encodeCQCode } from '@/onebot/helper/cqcode';
@@ -37,19 +37,24 @@ type RawToOb11Converters = {
         element: Exclude<MessageElement[Key], null | undefined>,
         msg: RawMessage,
         elementWrapper: MessageElement,
+        context: RecvMessageContext
     ) => PromiseLike<OB11MessageData | null>
 }
 
 type Ob11ToRawConverters = {
     [Key in OB11MessageDataType]: (
         sendMsg: Extract<OB11MessageData, { type: Key }>,
-        context: MessageContext,
+        context: SendMessageContext,
     ) => Promise<SendMessageElement | undefined>
 }
 
-export type MessageContext = {
+export type SendMessageContext = {
     deleteAfterSentFiles: string[],
     peer: Peer
+}
+
+export type RecvMessageContext = {
+    parseMultMsg: boolean
 }
 
 function keyCanBeParsed(key: string, parser: RawToOb11Converters): key is keyof RawToOb11Converters {
@@ -338,12 +343,7 @@ export class OneBotMsgApi {
             };
         },
 
-        multiForwardMsgElement: async (_, msg) => {
-            // const message_data: OB11MessageForward = {
-            //     data: {} as any,
-            //     type: OB11MessageDataType.forward,
-            // };
-            // message_data.data.id = msg.msgId;
+        multiForwardMsgElement: async (_, msg, wrapper, context) => {
             const parentMsgPeer = msg.parentMsgPeer ?? {
                 chatType: msg.chatType,
                 guildId: '',
@@ -359,21 +359,23 @@ export class OneBotMsgApi {
             //拉取下级消息
             if (!multiMsgs) return null;
             //拉取失败则跳过
-
-            return {
+            let ret = {
                 type: OB11MessageDataType.forward,
                 data: {
-                    id: msg.msgId,
-                    content: (await Promise.all(multiMsgs.map(
-                        async multiMsgItem => {
-                            multiMsgItem.parentMsgPeer = parentMsgPeer;
-                            multiMsgItem.parentMsgIdList = msg.parentMsgIdList;
-                            multiMsgItem.id = MessageUnique.createUniqueMsgId(parentMsgPeer, multiMsgItem.msgId); //该ID仅用查看 无法调用
-                            return await this.parseMessage(multiMsgItem, 'array');
-                        },
-                    ))).filter(item => item !== undefined),
+                    id: msg.msgId
                 },
-            };
+            } as OB11MessageForward;
+            if (context.parseMultMsg) {
+                ret.data.content = (await Promise.all(multiMsgs.map(
+                    async multiMsgItem => {
+                        multiMsgItem.parentMsgPeer = parentMsgPeer;
+                        multiMsgItem.parentMsgIdList = msg.parentMsgIdList;
+                        multiMsgItem.id = MessageUnique.createUniqueMsgId(parentMsgPeer, multiMsgItem.msgId); //该ID仅用查看 无法调用
+                        return await this.parseMessage(multiMsgItem, 'array', context.parseMultMsg);
+                    },
+                ))).filter(item => item !== undefined)
+            }
+            return ret;
         },
 
         arkElement: async (element) => {
@@ -695,15 +697,17 @@ export class OneBotMsgApi {
     async parseMessage(
         msg: RawMessage,
         messagePostFormat: string,
+        parseMultMsg: boolean = true
     ) {
         if (messagePostFormat === 'string') {
-            return (await this.parseMessageV2(msg))?.stringMsg;
+            return (await this.parseMessageV2(msg, parseMultMsg))?.stringMsg;
         }
-        return (await this.parseMessageV2(msg))?.arrayMsg;
+        return (await this.parseMessageV2(msg, parseMultMsg))?.arrayMsg;
     }
 
     async parseMessageV2(
         msg: RawMessage,
+        parseMultMsg: boolean = true
     ) {
         if (msg.senderUin == '0' || msg.senderUin == '') return;
         if (msg.peerUin == '0' || msg.peerUin == '') return;
@@ -767,11 +771,15 @@ export class OneBotMsgApi {
                             element: Exclude<MessageElement[keyof RawToOb11Converters], null | undefined>,
                             msg: RawMessage,
                             elementWrapper: MessageElement,
+                            context: RecvMessageContext
                         ) => PromiseLike<OB11MessageData | null>;
                         const parsedElement = await converters?.(
                             element[key],
                             msg,
                             element,
+                            {
+                                parseMultMsg: parseMultMsg
+                            }
                         );
                         // 对于 face 类型的消息，检查是否存在
                         if (key === 'faceElement' && !parsedElement) {
@@ -819,7 +827,7 @@ export class OneBotMsgApi {
             }
             const converter = this.ob11ToRawConverters[sendMsg.type] as (
                 sendMsg: Extract<OB11MessageData, { type: OB11MessageData['type'] }>,
-                context: MessageContext,
+                context: SendMessageContext,
             ) => Promise<SendMessageElement | undefined>;
             const callResult = converter(
                 sendMsg,
@@ -878,7 +886,7 @@ export class OneBotMsgApi {
 
     private async handleOb11FileLikeMessage(
         { data: inputdata }: OB11MessageFileBase,
-        { deleteAfterSentFiles }: MessageContext,
+        { deleteAfterSentFiles }: SendMessageContext,
     ) {
         const realUri = inputdata.url || inputdata.file || inputdata.path || '';
         if (realUri.length === 0) {

--- a/src/onebot/config/config.ts
+++ b/src/onebot/config/config.ts
@@ -154,8 +154,8 @@ export function mergeOneBotConfigs(
     if (userConfig.enableLocalFile2Url !== undefined) {
         mergedConfig.enableLocalFile2Url = userConfig.enableLocalFile2Url;
     }
-    if (userConfig.enableLocalFile2Url !== undefined) {
-        mergedConfig.enableLocalFile2Url = true;
+    if (userConfig.parseMultMsg !== undefined) {
+        mergedConfig.parseMultMsg = userConfig.parseMultMsg;
     }
     return mergedConfig;
 }

--- a/src/onebot/config/config.ts
+++ b/src/onebot/config/config.ts
@@ -103,6 +103,7 @@ export interface OneBotConfig {
     network: NetworkConfig; // 网络配置
     musicSignUrl: string; // 音乐签名地址
     enableLocalFile2Url: boolean;
+    parseMultMsg: boolean;
 }
 
 const createDefaultConfig = <T>(config: T): T => config;
@@ -116,6 +117,7 @@ export const defaultOneBotConfigs = createDefaultConfig<OneBotConfig>({
     },
     musicSignUrl: '',
     enableLocalFile2Url: false,
+    parseMultMsg: true
 });
 
 export const mergeNetworkDefaultConfig = {
@@ -149,8 +151,11 @@ export function mergeOneBotConfigs(
     if (userConfig.musicSignUrl !== undefined) {
         mergedConfig.musicSignUrl = userConfig.musicSignUrl;
     }
-    if(userConfig.enableLocalFile2Url !== undefined) {
+    if (userConfig.enableLocalFile2Url !== undefined) {
         mergedConfig.enableLocalFile2Url = userConfig.enableLocalFile2Url;
+    }
+    if (userConfig.enableLocalFile2Url !== undefined) {
+        mergedConfig.enableLocalFile2Url = true;
     }
     return mergedConfig;
 }

--- a/src/onebot/index.ts
+++ b/src/onebot/index.ts
@@ -551,7 +551,7 @@ export class NapCatOneBot11Adapter {
     }
     private async handleMsg(message: RawMessage, network: Array<AdapterConfigWrap>) {
         try {
-            const ob11Msg = await this.apis.MsgApi.parseMessageV2(message);
+            const ob11Msg = await this.apis.MsgApi.parseMessageV2(message, this.configLoader.configData.parseMultMsg);
             if (ob11Msg) {
                 const isSelfMsg = this.isSelfMessage(ob11Msg);
                 this.context.logger.logDebug('转化为 OB11Message', ob11Msg);

--- a/src/onebot/types/message.ts
+++ b/src/onebot/types/message.ts
@@ -236,7 +236,7 @@ export interface OB11MessageForward {
     type: OB11MessageDataType.forward;
     data: {
         id: string;
-        content: OB11Message[];
+        content?: OB11Message[];
     };
 }
 


### PR DESCRIPTION
## Summary by Sourcery

添加一个新功能，通过配置选项 'parseMultMsg' 控制多条消息的解析。重构消息解析逻辑以利用此新选项，并更新用户界面以允许用户切换此设置。

新功能：
- 引入一个新的配置选项 'parseMultMsg' 以启用或禁用多条消息的解析。

增强：
- 重构消息解析逻辑以包含 'parseMultMsg' 上下文，允许有条件地解析多条消息。

文档：
- 更新用户界面，在配置设置中包含 'parseMultMsg' 的新开关。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new feature to control the parsing of multiple messages through a configuration option 'parseMultMsg'. Refactor the message parsing logic to utilize this new option, and update the user interface to allow users to toggle this setting.

New Features:
- Introduce a new configuration option 'parseMultMsg' to enable or disable the parsing of multiple messages.

Enhancements:
- Refactor message parsing logic to include 'parseMultMsg' context, allowing conditional parsing of multiple messages.

Documentation:
- Update the user interface to include a new switch for 'parseMultMsg' in the configuration settings.

</details>