### PR TITLE
Feat: 支持快速基于NapCat进行二次开发 不需要通过传统NetWork

### DIFF
--- a/src/core/plugin/index.ts
+++ b/src/core/plugin/index.ts
@@ -1,10 +1,10 @@
-import { OB11Message } from "@/onebot";
+import { NapCatOneBot11Adapter, OB11Message } from "@/onebot";
+import SendGroupMsg from "@/onebot/action/group/SendGroupMsg";
 import { NapCatCore } from "..";
-import { ActionMap } from "@/onebot/action";
 
-export const plugin_onmessage = async (adapter: string, core: NapCatCore, action: ActionMap, message: OB11Message) => {
+export const plugin_onmessage = async (adapter: string, core: NapCatCore, obCore: NapCatOneBot11Adapter, message: OB11Message) => {
     if (message.raw_message === 'ping') {
-        const ret = await action.get('send_group_msg')?.handle({ group_id: message.group_id, message: 'pong' }, adapter);
+        const ret = await new SendGroupMsg(obCore, core).handle({ group_id: String(message.group_id), message: 'pong' }, adapter);
         console.log(ret);
     }
 }

--- a/src/core/plugin/index.ts
+++ b/src/core/plugin/index.ts
@@ -1,0 +1,10 @@
+import { OB11Message } from "@/onebot";
+import { NapCatCore } from "..";
+import { ActionMap } from "@/onebot/action";
+
+export const plugin_onmessage = async (adapter: string, core: NapCatCore, action: ActionMap, message: OB11Message) => {
+    if (message.raw_message === 'ping') {
+        const ret = await action.get('send_group_msg')?.handle({ group_id: message.group_id, message: 'pong' }, adapter);
+        console.log(ret);
+    }
+}

--- a/src/onebot/config/config.ts
+++ b/src/onebot/config/config.ts
@@ -28,6 +28,7 @@ interface v1Config {
 export interface AdapterConfigInner {
     name: string;
     enable: boolean;
+
 }
 export type AdapterConfigWrap = AdapterConfigInner & Partial<NetworkConfigAdapter>;
 
@@ -127,7 +128,7 @@ export const mergeNetworkDefaultConfig = {
     websocketClients: websocketClientDefaultConfigs,
 } as const;
 
-export type NetworkConfigAdapter = HttpServerConfig | HttpClientConfig | WebsocketServerConfig | WebsocketClientConfig;
+export type NetworkConfigAdapter = HttpServerConfig | HttpClientConfig | WebsocketServerConfig | WebsocketClientConfig | AdapterConfig;
 type NetworkConfigKeys = keyof typeof mergeNetworkDefaultConfig;
 
 export function mergeOneBotConfigs(

--- a/src/onebot/index.ts
+++ b/src/onebot/index.ts
@@ -111,7 +111,7 @@ export class NapCatOneBot11Adapter {
 
         // 注册Plugin
         this.networkManager.registerAdapter(
-            new OB11PluginAdapter('plugin', this.core, this.actions)
+            new OB11PluginAdapter('plugin', this.core, this,this.actions)
         );
         for (const key of ob11Config.network.httpServers) {
             if (key.enable) {

--- a/src/onebot/index.ts
+++ b/src/onebot/index.ts
@@ -109,10 +109,10 @@ export class NapCatOneBot11Adapter {
 
         //创建NetWork服务
 
-        // 注册Plugin
-        this.networkManager.registerAdapter(
-            new OB11PluginAdapter('plugin', this.core, this,this.actions)
-        );
+        // 注册Plugin 如果需要基于NapCat进行快速开发
+        // this.networkManager.registerAdapter(
+        //     new OB11PluginAdapter('plugin', this.core, this,this.actions)
+        // );
         for (const key of ob11Config.network.httpServers) {
             if (key.enable) {
                 this.networkManager.registerAdapter(

--- a/src/onebot/network/index.ts
+++ b/src/onebot/network/index.ts
@@ -34,7 +34,11 @@ export class OB11NetworkManager {
     }
 
     async emitEvent(event: OB11EmitEventContent) {
-        return Promise.all(Array.from(this.adapters.values()).map(adapter => adapter.onEvent(event)));
+        return Promise.all(Array.from(this.adapters.values()).map(adapter => {
+            if (adapter.isEnable) {
+                return adapter.onEvent(event);
+            }
+        }));
     }
 
     async emitEvents(events: OB11EmitEventContent[]) {
@@ -44,19 +48,21 @@ export class OB11NetworkManager {
     async emitEventByName(names: string[], event: OB11EmitEventContent) {
         return Promise.all(names.map(name => {
             const adapter = this.adapters.get(name);
-            if (adapter) {
+            if (adapter && adapter.isEnable) {
                 return adapter.onEvent(event);
             }
         }));
     }
+
     async emitEventByNames(map: Map<string, OB11EmitEventContent>) {
         return Promise.all(Array.from(map.entries()).map(([name, event]) => {
             const adapter = this.adapters.get(name);
-            if (adapter) {
+            if (adapter && adapter.isEnable) {
                 return adapter.onEvent(event);
             }
         }));
     }
+
     registerAdapter(adapter: IOB11NetworkAdapter) {
         this.adapters.set(adapter.name, adapter);
     }
@@ -103,6 +109,9 @@ export class OB11NetworkManager {
     }
     async readloadSomeAdapters<T>(configMap: Map<string, T>) {
         await Promise.all(Array.from(configMap.entries()).map(([name, config]) => this.readloadAdapter(name, config)));
+    }
+    async getAllConfig() {
+        return Array.from(this.adapters.values()).map(adapter => adapter.config);
     }
 }
 

--- a/src/onebot/network/plugin.ts
+++ b/src/onebot/network/plugin.ts
@@ -1,0 +1,44 @@
+import { IOB11NetworkAdapter, OB11EmitEventContent, OB11NetworkReloadType } from './index';
+import { OB11Message } from '@/onebot';
+import { NapCatCore } from '@/core';
+import { ActionMap } from '../action';
+import { AdapterConfig } from '../config/config';
+import { plugin_onmessage } from '@/core/plugin';
+
+export class OB11PluginAdapter implements IOB11NetworkAdapter {
+    isEnable: boolean = true;
+    public config: AdapterConfig;
+
+    constructor(
+        public name: string,
+        public core: NapCatCore,
+        public actions: ActionMap,
+    ) {
+        // 基础配置
+        this.config = {
+            name: name,
+            messagePostFormat: 'array',
+            reportSelfMessage: false,
+            enable: true,
+            debug: false,
+        }
+    }
+
+    onEvent<T extends OB11EmitEventContent>(event: T) {
+        if (event.post_type === 'message') {
+             plugin_onmessage(this.config.name, this.core, this.actions, event as OB11Message).then().catch();
+        }
+    }
+
+    open() {
+
+    }
+
+    async close() {
+
+    }
+
+    async reload() {
+        return OB11NetworkReloadType.Normal;
+    }
+}

--- a/src/onebot/network/plugin.ts
+++ b/src/onebot/network/plugin.ts
@@ -1,5 +1,5 @@
 import { IOB11NetworkAdapter, OB11EmitEventContent, OB11NetworkReloadType } from './index';
-import { OB11Message } from '@/onebot';
+import { NapCatOneBot11Adapter, OB11Message } from '@/onebot';
 import { NapCatCore } from '@/core';
 import { ActionMap } from '../action';
 import { AdapterConfig } from '../config/config';
@@ -12,6 +12,7 @@ export class OB11PluginAdapter implements IOB11NetworkAdapter {
     constructor(
         public name: string,
         public core: NapCatCore,
+        public obCore: NapCatOneBot11Adapter,
         public actions: ActionMap,
     ) {
         // 基础配置
@@ -26,7 +27,7 @@ export class OB11PluginAdapter implements IOB11NetworkAdapter {
 
     onEvent<T extends OB11EmitEventContent>(event: T) {
         if (event.post_type === 'message') {
-             plugin_onmessage(this.config.name, this.core, this.actions, event as OB11Message).then().catch();
+             plugin_onmessage(this.config.name, this.core, this.obCore, event as OB11Message).then().catch();
         }
     }
 


### PR DESCRIPTION
## Sourcery总结

在NapCatOneBot11Adapter中引入插件适配器机制，以增强事件处理的模块化和灵活性。通过添加适配器启用检查和检索所有适配器配置的方法，改进OB11NetworkManager。

新功能：
- 为NapCatOneBot11Adapter引入新的插件适配器机制，允许更灵活和模块化的事件处理。

增强功能：
- 在OB11NetworkManager中添加适配器启用检查，在处理事件之前提高效率，跳过禁用的适配器。
- 在OB11NetworkManager中实现检索所有适配器配置的方法，增强配置管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a plugin adapter mechanism to enhance the modularity and flexibility of event handling in the NapCatOneBot11Adapter. Improve the OB11NetworkManager by adding checks for adapter enablement and a method to retrieve all adapter configurations.

New Features:
- Introduce a new plugin adapter mechanism for the NapCatOneBot11Adapter, allowing for more flexible and modular event handling.

Enhancements:
- Add a check for adapter enablement before processing events in the OB11NetworkManager, improving efficiency by skipping disabled adapters.
- Implement a method to retrieve all adapter configurations in the OB11NetworkManager, enhancing configuration management.

</details>