### PR TITLE
优化私聊戳一戳事件上报

### DIFF
--- a/src/onebot/api/friend.ts
+++ b/src/onebot/api/friend.ts
@@ -12,16 +12,17 @@ export class OneBotFriendApi {
     }
 
     //使用前预先判断 busiId 1061
-    async parsePrivatePokeEvent(grayTipElement: GrayTipElement) {
+    async parsePrivatePokeEvent(grayTipElement: GrayTipElement, uin: number) {
         const json = JSON.parse(grayTipElement.jsonGrayTipElement.jsonStr);
-        let pokedetail: Array<{ uid: string }> = json.items;
+        const pokedetail: Array<{ uid: string }> = json.items;
         //筛选item带有uid的元素
-        pokedetail = pokedetail.filter(item => item.uid);
-        if (pokedetail.length == 2) {
+        const poke_uid = pokedetail.filter(item => item.uid);
+        if (poke_uid.length == 2) {
             return new OB11FriendPokeEvent(
                 this.core,
-                parseInt((await this.core.apis.UserApi.getUinByUidV2(pokedetail[0].uid))),
-                parseInt((await this.core.apis.UserApi.getUinByUidV2(pokedetail[1].uid))),
+                uin,
+                parseInt((await this.core.apis.UserApi.getUinByUidV2(poke_uid[0].uid))),
+                parseInt((await this.core.apis.UserApi.getUinByUidV2(poke_uid[1].uid))),
                 pokedetail,
             );
         }

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -679,7 +679,7 @@ export class OneBotMsgApi {
     async parsePrivateMsgEvent(msg: RawMessage, grayTipElement: GrayTipElement) {
         if (grayTipElement.subElementType == NTGrayTipElementSubTypeV2.GRAYTIP_ELEMENT_SUBTYPE_JSON) {
             if (grayTipElement.jsonGrayTipElement.busiId == 1061) {
-                const PokeEvent = await this.obContext.apis.FriendApi.parsePrivatePokeEvent(grayTipElement);
+                const PokeEvent = await this.obContext.apis.FriendApi.parsePrivatePokeEvent(grayTipElement, Number(await this.core.apis.UserApi.getUinByUidV2(msg.peerUid)));
                 if (PokeEvent) { return PokeEvent; };
             } else if (grayTipElement.jsonGrayTipElement.busiId == 19324 && msg.peerUid !== '') {
                 return new OB11FriendAddNoticeEvent(this.core, Number(await this.core.apis.UserApi.getUinByUidV2(msg.peerUid)));

--- a/src/onebot/event/notice/OB11PokeEvent.ts
+++ b/src/onebot/event/notice/OB11PokeEvent.ts
@@ -10,12 +10,14 @@ class OB11PokeEvent extends OB11BaseNoticeEvent {
 
 export class OB11FriendPokeEvent extends OB11PokeEvent {
     raw_info: any;
+    sender_id: number;
 
     //raw_message nb等框架标准为string
-    constructor(core: NapCatCore, user_id: number, target_id: number, raw_message: any) {
+    constructor(core: NapCatCore, user_id: number, sender_id: number, target_id: number, raw_message: any) {
         super(core);
         this.target_id = target_id;
         this.user_id = user_id;
+        this.sender_id = sender_id;
         this.raw_info = raw_message;
     }
 }


### PR DESCRIPTION
参考 https://docs.go-cqhttp.org/event/#%E5%A5%BD%E5%8F%8B%E6%88%B3%E4%B8%80%E6%88%B3-%E5%8F%8C%E5%87%BB%E5%A4%B4%E5%83%8F

添加 sender_id 为发起方 id，user_id 修改为当前聊天的对方 id。虽然 gocq 那边写的都是 发送者 QQ 号，但是我觉得 user_id 应该是当前会话 id，不然机器人在别人聊天里自己戳自己这个事件，就不知道是在哪个聊天里面戳的。并且应该也不会有两个一模一样用途的字段

## Summary by Sourcery

增强功能：
- 通过添加一个 `sender_id` 字段来表示发起者的 ID，并修改 `user_id` 以表示当前聊天中另一方的 ID，从而优化私人聊天戳事件的报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Optimize the reporting of private chat poke events by adding a sender_id field to represent the initiator's ID and modifying the user_id to represent the other party's ID in the current chat.

</details>