### PR TITLE
fix: wrong notice_type sub_type

### DIFF
--- a/src/onebot/event/notice/OB11GroupNameEvent.ts
+++ b/src/onebot/event/notice/OB11GroupNameEvent.ts
@@ -2,7 +2,8 @@ import { OB11GroupNoticeEvent } from './OB11GroupNoticeEvent';
 import { NapCatCore } from '@/core';
 
 export class OB11GroupNameEvent extends OB11GroupNoticeEvent {
-    notice_type = 'group_name';
+    notice_type = 'notify';
+    sub_type = 'group_name';
     name_new: string;
 
     constructor(core: NapCatCore, groupId: number, userId: number, nameNew: string) {


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 将 `notice_type` 更正为 `notify`，并为群组名称事件引入 `sub_type`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the `notice_type` to `notify` and introduce `sub_type` for group name events.

</details>