### PR TITLE
feat: download_file 支持 file://

### DIFF
--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -175,10 +175,9 @@ export async function checkUriType(Uri: string) {
     return { Uri: Uri, Type: FileUriType.Unknown };
 }
 
-export async function uriToLocalFile(dir: string, uri: string): Promise<Uri2LocalRes> {
+export async function uriToLocalFile(dir: string, uri: string, filename: string = randomUUID(), headers?: Record<string, string>): Promise<Uri2LocalRes> {
     const { Uri: HandledUri, Type: UriType } = await checkUriType(uri);
 
-    const filename = randomUUID();
     const filePath = path.join(dir, filename);
 
     switch (UriType) {
@@ -191,7 +190,7 @@ export async function uriToLocalFile(dir: string, uri: string): Promise<Uri2Loca
     }
 
     case FileUriType.Remote: {
-        const buffer = await httpDownload(HandledUri);
+        const buffer = await httpDownload({ url: HandledUri, headers: headers });
         fs.writeFileSync(filePath, buffer, { flag: 'wx' });
         return { success: true, errMsg: '', fileName: filename, path: filePath };
     }

--- a/src/onebot/action/go-cqhttp/DownloadFile.ts
+++ b/src/onebot/action/go-cqhttp/DownloadFile.ts
@@ -2,7 +2,7 @@ import { OneBotAction } from '@/onebot/action/OneBotAction';
 import { ActionName } from '@/onebot/action/router';
 import fs from 'fs';
 import { join as joinPath } from 'node:path';
-import { calculateFileMD5, httpDownload, uriToLocalFile } from '@/common/file';
+import { calculateFileMD5, uriToLocalFile } from '@/common/file';
 import { randomUUID } from 'crypto';
 import { Static, Type } from '@sinclair/typebox';
 

--- a/src/onebot/action/go-cqhttp/DownloadFile.ts
+++ b/src/onebot/action/go-cqhttp/DownloadFile.ts
@@ -30,6 +30,9 @@ export default class GoCQHTTPDownloadFile extends OneBotAction<Payload, FileResp
 
         if (payload.base64) {
             fs.writeFileSync(filePath, payload.base64, 'base64');
+        } else if (payload.url?.startsWith('file://')) {
+            const path = payload.url.substring(7);
+            fs.copyFileSync(path, filePath);
         } else if (payload.url) {
             const headers = this.getHeaders(payload.headers);
             const buffer = await httpDownload({ url: payload.url, headers: headers });

--- a/src/onebot/action/go-cqhttp/DownloadFile.ts
+++ b/src/onebot/action/go-cqhttp/DownloadFile.ts
@@ -2,7 +2,7 @@ import { OneBotAction } from '@/onebot/action/OneBotAction';
 import { ActionName } from '@/onebot/action/router';
 import fs from 'fs';
 import { join as joinPath } from 'node:path';
-import { calculateFileMD5, httpDownload } from '@/common/file';
+import { calculateFileMD5, httpDownload, uriToLocalFile } from '@/common/file';
 import { randomUUID } from 'crypto';
 import { Static, Type } from '@sinclair/typebox';
 
@@ -26,20 +26,20 @@ export default class GoCQHTTPDownloadFile extends OneBotAction<Payload, FileResp
     async _handle(payload: Payload): Promise<FileResponse> {
         const isRandomName = !payload.name;
         const name = payload.name || randomUUID();
-        const filePath = joinPath(this.core.NapCatTempPath, name);
+        let result: Awaited<ReturnType<typeof uriToLocalFile>>;
 
         if (payload.base64) {
-            fs.writeFileSync(filePath, payload.base64, 'base64');
-        } else if (payload.url?.startsWith('file://')) {
-            const path = payload.url.substring(7);
-            fs.copyFileSync(path, filePath);
+            result = await uriToLocalFile(this.core.NapCatTempPath, `base64://${payload.base64}`, name);
         } else if (payload.url) {
             const headers = this.getHeaders(payload.headers);
-            const buffer = await httpDownload({ url: payload.url, headers: headers });
-            fs.writeFileSync(filePath, Buffer.from(buffer), 'binary');
+            result = await uriToLocalFile(this.core.NapCatTempPath, payload.url, name, headers);
         } else {
             throw new Error('不存在任何文件, 无法下载');
         }
+        if (!result.success) {
+            throw new Error(result.errMsg);
+        }
+        const filePath = result.path;
         if (fs.existsSync(filePath)) {
 
             if (isRandomName) {


### PR DESCRIPTION
Q2TG 需要在收到语音的时候把语音弄到共享存储目录里

## Summary by Sourcery

新功能：
- 支持使用 `file://` URL 方案从本地路径下载文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support downloading files from local paths using the `file://` URL scheme.

</details>
- 支持使用 `file://` URL 方案从本地路径下载文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

新功能：
- 支持使用 `file://` URL 方案从本地路径下载文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support downloading files from local paths using the `file://` URL scheme.

</details>

</details>