### PR TITLE
fix #678

### DIFF
--- a/src/webui/src/helper/config.ts
+++ b/src/webui/src/helper/config.ts
@@ -90,7 +90,7 @@ export class WebUiConfigWrapper {
         try {
             const configPath = resolve(webUiPathWrapper.configPath, './webui.json');
 
-            if (!await fs.access(configPath, constants.R_OK).then(() => true).catch(() => false)) {
+            if (!await fs.access(configPath, constants.F_OK).then(() => true).catch(() => false)) {
                 await fs.writeFile(configPath, JSON.stringify(defaultconfig, null, 4));
             }
 
@@ -101,7 +101,9 @@ export class WebUiConfigWrapper {
             if (!parsedConfig.prefix.startsWith('/')) parsedConfig.prefix = '/' + parsedConfig.prefix;
             if (parsedConfig.prefix.endsWith('/')) parsedConfig.prefix = parsedConfig.prefix.slice(0, -1);
             // 配置已经被操作过了，还是回写一下吧，不然新配置不会出现在配置文件里
-            await fs.writeFile(configPath, JSON.stringify(parsedConfig, null, 4));
+            if (!await fs.access(configPath, constants.W_OK).then(() => true).catch(() => false)) {
+                await fs.writeFile(configPath, JSON.stringify(parsedConfig, null, 4));
+            }
             // 不希望回写的配置放后面
 
             // 查询主机地址是否可用

--- a/src/webui/src/helper/config.ts
+++ b/src/webui/src/helper/config.ts
@@ -101,7 +101,7 @@ export class WebUiConfigWrapper {
             if (!parsedConfig.prefix.startsWith('/')) parsedConfig.prefix = '/' + parsedConfig.prefix;
             if (parsedConfig.prefix.endsWith('/')) parsedConfig.prefix = parsedConfig.prefix.slice(0, -1);
             // 配置已经被操作过了，还是回写一下吧，不然新配置不会出现在配置文件里
-            if (!await fs.access(configPath, constants.W_OK).then(() => true).catch(() => false)) {
+            if (await fs.access(configPath, constants.W_OK).then(() => true).catch(() => false)) {
                 await fs.writeFile(configPath, JSON.stringify(parsedConfig, null, 4));
             }
             // 不希望回写的配置放后面

--- a/src/webui/src/helper/config.ts
+++ b/src/webui/src/helper/config.ts
@@ -104,6 +104,9 @@ export class WebUiConfigWrapper {
             if (await fs.access(configPath, constants.W_OK).then(() => true).catch(() => false)) {
                 await fs.writeFile(configPath, JSON.stringify(parsedConfig, null, 4));
             }
+            else {
+                console.warn(`文件: ${configPath} 没有写入权限, 配置的更改部分可能会在重启后还原.`);
+            }
             // 不希望回写的配置放后面
 
             // 查询主机地址是否可用


### PR DESCRIPTION
## Summary by Sourcery

Bug 修复：
- 确保如果配置文件存在但不可读，仍然能够写入 webui 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the webui config is written if the file exists but is not readable.

</details>