### PR TITLE
HTTP SSE 消息上报模式

### DIFF
--- a/src/onebot/config/config.ts
+++ b/src/onebot/config/config.ts
@@ -59,6 +59,13 @@ export const httpServerDefaultConfigs = createDefaultAdapterConfig({
 });
 export type HttpServerConfig = typeof httpServerDefaultConfigs;
 
+export const httpSseServerDefaultConfigs = createDefaultAdapterConfig({
+    ...httpServerDefaultConfigs,
+    name: 'http-sse-server',
+    reportSelfMessage: false,
+});
+export type HttpSseServerConfig = typeof httpSseServerDefaultConfigs;
+
 export const httpClientDefaultConfigs = createDefaultAdapterConfig({
     name: 'http-client',
     enable: false as boolean,
@@ -99,6 +106,7 @@ export type WebsocketClientConfig = typeof websocketClientDefaultConfigs;
 
 export interface NetworkConfig {
     httpServers: Array<HttpServerConfig>;
+    httpSseServers: Array<HttpSseServerConfig>;
     httpClients: Array<HttpClientConfig>;
     websocketServers: Array<WebsocketServerConfig>;
     websocketClients: Array<WebsocketClientConfig>;
@@ -120,6 +128,7 @@ const createDefaultConfig = <T>(config: T): T => config;
 export const defaultOneBotConfigs = createDefaultConfig<OneBotConfig>({
     network: {
         httpServers: [],
+        httpSseServers: [],
         httpClients: [],
         websocketServers: [],
         websocketClients: [],

--- a/src/onebot/index.ts
+++ b/src/onebot/index.ts
@@ -53,6 +53,7 @@ import {
 import { OB11Message } from './types';
 import { OB11PluginAdapter } from './network/plugin';
 import { IOB11NetworkAdapter } from "@/onebot/network/adapter";
+import { OB11ActiveHttpSSEAdapter } from './network/active-http-sse';
 
 //OneBot实现类
 export class NapCatOneBot11Adapter {
@@ -86,6 +87,9 @@ export class NapCatOneBot11Adapter {
         let log = `[network] 配置加载\n`;
         for (const key of ob11Config.network.httpServers) {
             log += `HTTP服务: ${key.host}:${key.port}, : ${key.enable ? '已启动' : '未启动'}\n`;
+        }
+        for (const key of ob11Config.network.httpSseServers) {
+            log += `HTTP-SSE服务: ${key.host}:${key.port}, : ${key.enable ? '已启动' : '未启动'}\n`;
         }
         for (const key of ob11Config.network.httpClients) {
             log += `HTTP上报服务: ${key.url}, : ${key.enable ? '已启动' : '未启动'}\n`;
@@ -122,6 +126,13 @@ export class NapCatOneBot11Adapter {
             if (key.enable) {
                 this.networkManager.registerAdapter(
                     new OB11PassiveHttpAdapter(key.name, key, this.core, this, this.actions)
+                );
+            }
+        }
+        for(const key of ob11Config.network.httpSseServers){
+            if(key.enable) {
+                this.networkManager.registerAdapter(
+                    new OB11ActiveHttpSSEAdapter(key.name, key, this.core, this, this.actions)
                 );
             }
         }
@@ -389,7 +400,7 @@ export class NapCatOneBot11Adapter {
                     ) {
                         this.context.logger.logDebug('有加群请求');
                         try {
-                            let requestUin = await this.core.apis.UserApi.getUinByUidV2(notify.user1.uid);
+                            const requestUin = await this.core.apis.UserApi.getUinByUidV2(notify.user1.uid);
                             const groupRequestEvent = new OB11GroupRequestEvent(
                                 this.core,
                                 parseInt(notify.group.groupCode),

--- a/src/onebot/network/active-http-sse.ts
+++ b/src/onebot/network/active-http-sse.ts
@@ -7,36 +7,10 @@ export class OB11ActiveHttpSSEAdapter extends OB11PassiveHttpAdapter {
     private sseClients: Response[] = [];
 
     async handleRequest(req: Request, res: Response): Promise<any> {
-        if (!this.isEnable) {
-            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Server is closed`);
-            return res.json(OB11Response.error('Server is closed', 200));
-        }
-
-        let payload = req.body;
-        if (req.method == 'get') {
-            payload = req.query;
-        } else if (req.query) {
-            payload = { ...req.query, ...req.body };
-        }
-        if (req.path === '' || req.path === '/') {
-            const hello = OB11Response.ok({});
-            hello.message = 'NapCat4 Ss Running';
-            return res.json(hello);
-        }
         if (req.path === '/_events') {
             return this.createSseSupport(req, res);
-        }
-        const actionName = req.path.split('/')[1];
-        const action = this.actions.get(actionName as any);
-        if (action) {
-            try {
-                const result = await action.handle(payload, this.name);
-                return res.json(result);
-            } catch (error: any) {
-                return res.json(OB11Response.error(error?.stack?.toString() || error?.message || 'Error Handle', 200));
-            }
         } else {
-            return res.json(OB11Response.error('不支持的Api ' + actionName, 200));
+            super.httpApiRequest(req, res);
         }
     }
 

--- a/src/onebot/network/active-http-sse.ts
+++ b/src/onebot/network/active-http-sse.ts
@@ -1,0 +1,60 @@
+import { OB11EmitEventContent } from './index';
+import { Request, Response } from 'express';
+import { OB11Response } from '@/onebot/action/OneBotAction';
+import { OB11PassiveHttpAdapter } from './passive-http';
+
+export class OB11ActiveHttpSSEAdapter extends OB11PassiveHttpAdapter {
+    private sseClients: Response[] = [];
+
+    async handleRequest(req: Request, res: Response): Promise<any> {
+        if (!this.isEnable) {
+            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Server is closed`);
+            return res.json(OB11Response.error('Server is closed', 200));
+        }
+
+        let payload = req.body;
+        if (req.method == 'get') {
+            payload = req.query;
+        } else if (req.query) {
+            payload = { ...req.query, ...req.body };
+        }
+        if (req.path === '' || req.path === '/') {
+            const hello = OB11Response.ok({});
+            hello.message = 'NapCat4 Ss Running';
+            return res.json(hello);
+        }
+        if (req.path === '/_events') {
+            return this.createSseSupport(req, res);
+        }
+        const actionName = req.path.split('/')[1];
+        const action = this.actions.get(actionName as any);
+        if (action) {
+            try {
+                const result = await action.handle(payload, this.name);
+                return res.json(result);
+            } catch (error: any) {
+                return res.json(OB11Response.error(error?.stack?.toString() || error?.message || 'Error Handle', 200));
+            }
+        } else {
+            return res.json(OB11Response.error('不支持的Api ' + actionName, 200));
+        }
+    }
+
+    private async createSseSupport(req: Request, res: Response) {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+        res.flushHeaders();
+        
+        this.sseClients.push(res);
+        req.on('close', () => {
+            this.sseClients = this.sseClients.filter((client) => client !== res);
+        });
+    }
+
+    onEvent<T extends OB11EmitEventContent>(event: T) {
+        this.sseClients.forEach((res) => {
+            res.write(`data: ${JSON.stringify(event)}\n\n`);
+        });
+    }
+}

--- a/src/onebot/network/passive-http.ts
+++ b/src/onebot/network/passive-http.ts
@@ -1,4 +1,4 @@
-import { OB11NetworkReloadType } from './index';
+import { OB11EmitEventContent, OB11NetworkReloadType } from './index';
 import express, { Express, Request, Response } from 'express';
 import http from 'http';
 import { NapCatCore } from '@/core';
@@ -17,7 +17,7 @@ export class OB11PassiveHttpAdapter extends IOB11NetworkAdapter<HttpServerConfig
         super(name, config, core, obContext, actions);
     }
 
-    onEvent() {
+    onEvent<T extends OB11EmitEventContent>(event: T) {
         // http server is passive, no need to emit event
     }
 
@@ -82,7 +82,7 @@ export class OB11PassiveHttpAdapter extends IOB11NetworkAdapter<HttpServerConfig
         }
     }
 
-    private async handleRequest(req: Request, res: Response) {
+    async handleRequest(req: Request, res: Response) {
         if (!this.isEnable) {
             this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Server is closed`);
             return res.json(OB11Response.error('Server is closed', 200));

--- a/src/onebot/network/passive-http.ts
+++ b/src/onebot/network/passive-http.ts
@@ -82,12 +82,7 @@ export class OB11PassiveHttpAdapter extends IOB11NetworkAdapter<HttpServerConfig
         }
     }
 
-    async handleRequest(req: Request, res: Response) {
-        if (!this.isEnable) {
-            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Server is closed`);
-            return res.json(OB11Response.error('Server is closed', 200));
-        }
-
+    async httpApiRequest(req: Request, res: Response) {
         let payload = req.body;
         if (req.method == 'get') {
             payload = req.query;
@@ -111,6 +106,15 @@ export class OB11PassiveHttpAdapter extends IOB11NetworkAdapter<HttpServerConfig
         } else {
             return res.json(OB11Response.error('不支持的Api ' + actionName, 200));
         }
+    }
+
+    async handleRequest(req: Request, res: Response) {
+        if (!this.isEnable) {
+            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Server is closed`);
+            return res.json(OB11Response.error('Server is closed', 200));
+        }
+
+        return this.httpApiRequest(req, res);
     }
 
     async reload(newConfig: HttpServerConfig) {


### PR DESCRIPTION
支持使用更轻量的 http sse 进行消息上报，作为 http client 反向连接的可选替代品。

![image](https://github.com/user-attachments/assets/4222485b-7148-4972-805a-9fab511ab433)

### 新增连接器：httpSseServers
配置文件继承自 httpServers，增加 reportSelfMessage 配置：
~~~json
"httpSseServers": [
  {
    "name": "http-sse",
    "enable": true,
    "port": 3000,
    "host": "0.0.0.0",
    "enableCors": true,
    "enableWebsocket": false,
    "messagePostFormat": "array",
    "token": "",
    "debug": false,
    "reportSelfMessage": true,
    "type": "HTTP-SSE 服务器"
  }
]
~~~

## Summary by Sourcery

新功能：
- 引入 HTTP SSE 作为消息报告的轻量级 HTTP 客户端反向连接替代方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce HTTP SSE as a lightweight alternative to HTTP client reverse connections for message reporting.

</details>