### PR TITLE
为新的接龙表情提供 resultId 和 chainCount 返回

### DIFF
--- a/src/core/packet/message/element.ts
+++ b/src/core/packet/message/element.ts
@@ -160,10 +160,12 @@ export class PacketMsgReplyElement extends IPacketMsgElement<SendReplyElement> {
 export class PacketMsgFaceElement extends IPacketMsgElement<SendFaceElement> {
     faceId: number;
     isLargeFace: boolean;
+    resultId?: string;
 
     constructor(element: SendFaceElement) {
         super(element);
         this.faceId = element.faceElement.faceIndex;
+        this.resultId = element.faceElement.resultId;
         this.isLargeFace = element.faceElement.faceType === FaceType.AniSticke;
     }
 
@@ -176,10 +178,10 @@ export class PacketMsgFaceElement extends IPacketMsgElement<SendFaceElement> {
                         aniStickerPackId: "1",
                         aniStickerId: "8",
                         faceId: this.faceId,
-                        field4: 1,
-                        field6: "",
+                        sourceType: 1,
+                        resultId: this.resultId,
                         preview: "",
-                        field9: 1
+                        ramdomType: 1
                     }),
                     businessType: 1
                 }

--- a/src/core/packet/message/element.ts
+++ b/src/core/packet/message/element.ts
@@ -181,7 +181,7 @@ export class PacketMsgFaceElement extends IPacketMsgElement<SendFaceElement> {
                         sourceType: 1,
                         resultId: this.resultId,
                         preview: "",
-                        ramdomType: 1
+                        randomType: 1
                     }),
                     businessType: 1
                 }

--- a/src/core/packet/transformer/proto/message/element.ts
+++ b/src/core/packet/transformer/proto/message/element.ts
@@ -342,11 +342,11 @@ export const QBigFaceExtra = {
     AniStickerPackId: ProtoField(1, ScalarType.STRING, true),
     AniStickerId: ProtoField(2, ScalarType.STRING, true),
     faceId: ProtoField(3, ScalarType.INT32, true),
-    Field4: ProtoField(4, ScalarType.INT32, true),
+    sourceType: ProtoField(4, ScalarType.INT32, true),
     AniStickerType: ProtoField(5, ScalarType.INT32, true),
-    field6: ProtoField(6, ScalarType.STRING, true),
+    resultId: ProtoField(6, ScalarType.STRING, true),
     preview: ProtoField(7, ScalarType.STRING, true),
-    field9: ProtoField(9, ScalarType.INT32, true),
+    ramdomType: ProtoField(9, ScalarType.INT32, true),
 };
 
 export const QSmallFaceExtra = {

--- a/src/core/packet/transformer/proto/message/element.ts
+++ b/src/core/packet/transformer/proto/message/element.ts
@@ -346,7 +346,7 @@ export const QBigFaceExtra = {
     AniStickerType: ProtoField(5, ScalarType.INT32, true),
     resultId: ProtoField(6, ScalarType.STRING, true),
     preview: ProtoField(7, ScalarType.STRING, true),
-    ramdomType: ProtoField(9, ScalarType.INT32, true),
+    randomType: ProtoField(9, ScalarType.INT32, true),
 };
 
 export const QSmallFaceExtra = {

--- a/src/core/types/element.ts
+++ b/src/core/types/element.ts
@@ -40,6 +40,7 @@ export interface FaceElement {
     resultId?: string;
     surpriseId?: string;
     randomType?: number;
+    chainCount?: number;
 }
 export interface GrayTipRovokeElement {
     operatorRole: string;

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -494,7 +494,7 @@ export class OneBotMsgApi {
                     stickerType: face.AniStickerType,
                     packId: face.AniStickerPackId,
                     sourceType: 1,
-                    resultId,
+                    resultId: resultId?.toString(),
                     chainCount,
                 },
             };

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -190,7 +190,10 @@ export class OneBotMsgApi {
                 return {
                     type: OB11MessageDataType.face,
                     data: {
-                        id: element.faceIndex.toString()
+                        id: element.faceIndex.toString(),
+                        raw: element,
+                        resultId: element.resultId,
+                        chainCount: element.chainCount,
                     },
                 };
             }
@@ -464,7 +467,7 @@ export class OneBotMsgApi {
                 undefined;
         },
 
-        [OB11MessageDataType.face]: async ({ data: { id } }) => {
+        [OB11MessageDataType.face]: async ({ data: { id, resultId, chainCount } }) => {
             const parsedFaceId = +id;
             // 从face_config.json中获取表情名称
             const sysFaces = faceConfig.sysface;
@@ -491,6 +494,8 @@ export class OneBotMsgApi {
                     stickerType: face.AniStickerType,
                     packId: face.AniStickerPackId,
                     sourceType: 1,
+                    resultId,
+                    chainCount,
                 },
             };
         },

--- a/src/onebot/types/message.ts
+++ b/src/onebot/types/message.ts
@@ -164,6 +164,8 @@ export interface OB11MessageFace {
     type: OB11MessageDataType.face;
     data: {
         id: string;
+        resultId?: string;
+        chainCount?: number;
     };
 }
 


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 如果可用，人脸消息现在包含 `resultId` 和 `chainCount`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Face messages now include `resultId` and `chainCount` if available.

</details>