### PR TITLE
fix: 无法修改网络配置表单值

### DIFF
--- a/napcat.webui/src/pages/NetWork.vue
+++ b/napcat.webui/src/pages/NetWork.vue
@@ -149,8 +149,10 @@
                     </t-select>
                 </t-form-item>
                 <div>
-                    <component :is="resolveDynamicComponent(getComponent(newTab.type as ComponentKey))"
-                        :config="newTab.data" />
+                    <component
+                        :is="resolveDynamicComponent(getComponent(newTab.type as ComponentKey))"
+                        :config="newTab"
+                    />
                 </div>
             </t-form>
         </div>

--- a/napcat.webui/src/pages/network/HttpClientComponent.vue
+++ b/napcat.webui/src/pages/network/HttpClientComponent.vue
@@ -2,22 +2,22 @@
     <div>
         <t-form labelAlign="left">
             <t-form-item label="启用">
-                <t-switch v-model="config.enable" />
+                <t-switch v-model="props.config.data.enable" />
             </t-form-item>
             <t-form-item label="URL">
-                <t-input v-model="config.url" />
+                <t-input v-model="props.config.data.url" />
             </t-form-item>
             <t-form-item label="消息格式">
-                <t-select v-model="config.messagePostFormat" :options="messageFormatOptions" />
+                <t-select v-model="props.config.data.messagePostFormat" :options="messageFormatOptions" />
             </t-form-item>
             <t-form-item label="报告自身消息">
-                <t-switch v-model="config.reportSelfMessage" />
+                <t-switch v-model="props.config.data.reportSelfMessage" />
             </t-form-item>
             <t-form-item label="Token">
-                <t-input v-model="config.token" />
+                <t-input v-model="props.config.data.token" />
             </t-form-item>
             <t-form-item label="调试模式">
-                <t-switch v-model="config.debug" />
+                <t-switch v-model="props.config.data.debug" />
             </t-form-item>
         </t-form>
     </div>
@@ -34,14 +34,14 @@ const defaultConfig: HttpClientConfig = {
     messagePostFormat: 'array',
     reportSelfMessage: false,
     token: '',
-    debug: false
+    debug: false,
 };
 
 const props = defineProps<{
-    config: HttpClientConfig;
+    config: { data: HttpClientConfig };
 }>();
 
-const config = ref(Object.assign({}, defaultConfig, props.config));
+props.config.data = { ...defaultConfig, ...props.config.data };
 
 const messageFormatOptions = ref([
     { label: 'Array', value: 'array' },
@@ -49,10 +49,10 @@ const messageFormatOptions = ref([
 ]);
 
 watch(
-    () => config.value.messagePostFormat,
+    () => props.config.data.messagePostFormat,
     (newValue) => {
         if (newValue !== 'array' && newValue !== 'string') {
-            config.value.messagePostFormat = 'array';
+            props.config.data.messagePostFormat = 'array';
         }
     }
 );

--- a/napcat.webui/src/pages/network/HttpServerComponent.vue
+++ b/napcat.webui/src/pages/network/HttpServerComponent.vue
@@ -2,28 +2,28 @@
     <div>
         <t-form labelAlign="left">
             <t-form-item label="启用">
-                <t-switch v-model="config.enable" />
+                <t-switch v-model="props.config.data.enable" />
             </t-form-item>
             <t-form-item label="端口">
-                <t-input v-model.number="config.port" type="number" />
+                <t-input v-model.number="props.config.data.port" type="number" />
             </t-form-item>
             <t-form-item label="主机">
-                <t-input v-model="config.host" type="text" />
+                <t-input v-model="props.config.data.host" type="text" />
             </t-form-item>
             <t-form-item label="启用 CORS">
-                <t-switch v-model="config.enableCors" />
+                <t-switch v-model="props.config.data.enableCors" />
             </t-form-item>
             <t-form-item label="启用 WS">
-                <t-switch v-model="config.enableWebsocket" />
+                <t-switch v-model="props.config.data.enableWebsocket" />
             </t-form-item>
             <t-form-item label="消息格式">
-                <t-select v-model="config.messagePostFormat" :options="messageFormatOptions" />
+                <t-select v-model="props.config.data.messagePostFormat" :options="messageFormatOptions" />
             </t-form-item>
             <t-form-item label="Token">
-                <t-input v-model="config.token" type="text" />
+                <t-input v-model="props.config.data.token" type="text" />
             </t-form-item>
             <t-form-item label="调试模式">
-                <t-switch v-model="config.debug" />
+                <t-switch v-model="props.config.data.debug" />
             </t-form-item>
         </t-form>
     </div>
@@ -42,14 +42,14 @@ const defaultConfig: HttpServerConfig = {
     enableWebsocket: true,
     messagePostFormat: 'array',
     token: '',
-    debug: false
+    debug: false,
 };
 
 const props = defineProps<{
-    config: HttpServerConfig;
+    config: { data: HttpServerConfig };
 }>();
 
-const config = ref(Object.assign({}, defaultConfig, props.config));
+props.config.data = { ...defaultConfig, ...props.config.data };
 
 const messageFormatOptions = ref([
     { label: 'Array', value: 'array' },
@@ -57,10 +57,10 @@ const messageFormatOptions = ref([
 ]);
 
 watch(
-    () => config.value.messagePostFormat,
+    () => props.config.data.messagePostFormat,
     (newValue) => {
         if (newValue !== 'array' && newValue !== 'string') {
-            config.value.messagePostFormat = 'array';
+            props.config.data.messagePostFormat = 'array';
         }
     }
 );

--- a/napcat.webui/src/pages/network/HttpSseServerComponent.vue
+++ b/napcat.webui/src/pages/network/HttpSseServerComponent.vue
@@ -2,31 +2,31 @@
     <div>
         <t-form labelAlign="left">
             <t-form-item label="启用">
-                <t-switch v-model="config.enable" />
+                <t-switch v-model="props.config.data.enable" />
             </t-form-item>
             <t-form-item label="端口">
-                <t-input v-model.number="config.port" type="number" />
+                <t-input v-model.number="props.config.data.port" type="number" />
             </t-form-item>
             <t-form-item label="主机">
-                <t-input v-model="config.host" type="text" />
+                <t-input v-model="props.config.data.host" type="text" />
             </t-form-item>
             <t-form-item label="报告自身消息">
-                <t-switch v-model="config.reportSelfMessage" />
+                <t-switch v-model="props.config.data.reportSelfMessage" />
             </t-form-item>
             <t-form-item label="启用 CORS">
-                <t-switch v-model="config.enableCors" />
+                <t-switch v-model="props.config.data.enableCors" />
             </t-form-item>
             <t-form-item label="启用 WS">
-                <t-switch v-model="config.enableWebsocket" />
+                <t-switch v-model="props.config.data.enableWebsocket" />
             </t-form-item>
             <t-form-item label="消息格式">
-                <t-select v-model="config.messagePostFormat" :options="messageFormatOptions" />
+                <t-select v-model="props.config.data.messagePostFormat" :options="messageFormatOptions" />
             </t-form-item>
             <t-form-item label="Token">
-                <t-input v-model="config.token" type="text" />
+                <t-input v-model="props.config.data.token" type="text" />
             </t-form-item>
             <t-form-item label="调试模式">
-                <t-switch v-model="config.debug" />
+                <t-switch v-model="props.config.data.debug" />
             </t-form-item>
         </t-form>
     </div>
@@ -46,14 +46,14 @@ const defaultConfig: HttpSseServerConfig = {
     messagePostFormat: 'array',
     token: '',
     debug: false,
-    reportSelfMessage: false
+    reportSelfMessage: false,
 };
 
 const props = defineProps<{
-    config: HttpSseServerConfig;
+    config: { data: HttpSseServerConfig };
 }>();
 
-const config = ref(Object.assign({}, defaultConfig, props.config));
+props.config.data = { ...defaultConfig, ...props.config.data };
 
 const messageFormatOptions = ref([
     { label: 'Array', value: 'array' },
@@ -61,10 +61,10 @@ const messageFormatOptions = ref([
 ]);
 
 watch(
-    () => config.value.messagePostFormat,
+    () => props.config.data.messagePostFormat,
     (newValue) => {
         if (newValue !== 'array' && newValue !== 'string') {
-            config.value.messagePostFormat = 'array';
+            props.config.data.messagePostFormat = 'array';
         }
     }
 );

--- a/napcat.webui/src/pages/network/WebsocketClientComponent.vue
+++ b/napcat.webui/src/pages/network/WebsocketClientComponent.vue
@@ -2,25 +2,25 @@
     <div>
         <t-form labelAlign="left">
             <t-form-item label="启用">
-                <t-switch v-model="config.enable" />
+                <t-switch v-model="props.config.data.enable" />
             </t-form-item>
             <t-form-item label="URL">
-                <t-input v-model="config.url" />
+                <t-input v-model="props.config.data.url" />
             </t-form-item>
             <t-form-item label="消息格式">
-                <t-select v-model="config.messagePostFormat" :options="messageFormatOptions" />
+                <t-select v-model="props.config.data.messagePostFormat" :options="messageFormatOptions" />
             </t-form-item>
             <t-form-item label="报告自身消息">
-                <t-switch v-model="config.reportSelfMessage" />
+                <t-switch v-model="props.config.data.reportSelfMessage" />
             </t-form-item>
             <t-form-item label="Token">
-                <t-input v-model="config.token" />
+                <t-input v-model="props.config.data.token" />
             </t-form-item>
             <t-form-item label="调试模式">
-                <t-switch v-model="config.debug" />
+                <t-switch v-model="props.config.data.debug" />
             </t-form-item>
             <t-form-item label="心跳间隔">
-                <t-input v-model.number="config.heartInterval" type="number" />
+                <t-input v-model.number="props.config.data.heartInterval" type="number" />
             </t-form-item>
         </t-form>
     </div>
@@ -39,14 +39,14 @@ const defaultConfig: WebsocketClientConfig = {
     reconnectInterval: 5000,
     token: '',
     debug: false,
-    heartInterval: 30000
+    heartInterval: 30000,
 };
 
 const props = defineProps<{
-    config: WebsocketClientConfig;
+    config: { data: WebsocketClientConfig };
 }>();
 
-const config = ref(Object.assign({}, defaultConfig, props.config));
+props.config.data = { ...defaultConfig, ...props.config.data };
 
 const messageFormatOptions = ref([
     { label: 'Array', value: 'array' },
@@ -54,10 +54,10 @@ const messageFormatOptions = ref([
 ]);
 
 watch(
-    () => config.value.messagePostFormat,
+    () => props.config.data.messagePostFormat,
     (newValue) => {
         if (newValue !== 'array' && newValue !== 'string') {
-            config.value.messagePostFormat = 'array';
+            props.config.data.messagePostFormat = 'array';
         }
     }
 );

--- a/napcat.webui/src/pages/network/WebsocketServerComponent.vue
+++ b/napcat.webui/src/pages/network/WebsocketServerComponent.vue
@@ -2,31 +2,31 @@
     <div>
         <t-form labelAlign="left">
             <t-form-item label="启用">
-                <t-switch v-model="config.enable" />
+                <t-switch v-model="props.config.data.enable" />
             </t-form-item>
             <t-form-item label="主机">
-                <t-input v-model="config.host" />
+                <t-input v-model="props.config.data.host" />
             </t-form-item>
             <t-form-item label="端口">
-                <t-input v-model.number="config.port" type="number" />
+                <t-input v-model.number="props.config.data.port" type="number" />
             </t-form-item>
             <t-form-item label="消息格式">
-                <t-select v-model="config.messagePostFormat" :options="messageFormatOptions" />
+                <t-select v-model="props.config.data.messagePostFormat" :options="messageFormatOptions" />
             </t-form-item>
             <t-form-item label="上报自身消息">
-                <t-switch v-model="config.reportSelfMessage" />
+                <t-switch v-model="props.config.data.reportSelfMessage" />
             </t-form-item>
             <t-form-item label="Token">
-                <t-input v-model="config.token" />
+                <t-input v-model="props.config.data.token" />
             </t-form-item>
             <t-form-item label="强制推送事件">
-                <t-switch v-model="config.enableForcePushEvent" />
+                <t-switch v-model="props.config.data.enableForcePushEvent" />
             </t-form-item>
             <t-form-item label="调试模式">
-                <t-switch v-model="config.debug" />
+                <t-switch v-model="props.config.data.debug" />
             </t-form-item>
             <t-form-item label="心跳间隔">
-                <t-input v-model.number="config.heartInterval" type="number" />
+                <t-input v-model.number="props.config.data.heartInterval" type="number" />
             </t-form-item>
         </t-form>
     </div>
@@ -46,14 +46,14 @@ const defaultConfig: WebsocketServerConfig = {
     token: '',
     enableForcePushEvent: true,
     debug: false,
-    heartInterval: 30000
+    heartInterval: 30000,
 };
 
 const props = defineProps<{
-    config: WebsocketServerConfig;
+    config: { data: WebsocketServerConfig };
 }>();
 
-const config = ref(Object.assign({}, defaultConfig, props.config));
+props.config.data = { ...defaultConfig, ...props.config.data };
 
 const messageFormatOptions = ref([
     { label: 'Array', value: 'array' },
@@ -61,10 +61,10 @@ const messageFormatOptions = ref([
 ]);
 
 watch(
-    () => config.value.messagePostFormat,
+    () => props.config.data.messagePostFormat,
     (newValue) => {
         if (newValue !== 'array' && newValue !== 'string') {
-            config.value.messagePostFormat = 'array';
+            props.config.data.messagePostFormat = 'array';
         }
     }
 );


### PR DESCRIPTION
由于子表单组件中单独维护了一份表单值, 导致外层组件取不到最新的值, 新增修改网络配置时接口传参错误

![PixPin_2025-01-22_01-33-04](https://github.com/user-attachments/assets/d8e41b71-55fd-4b7b-b4bb-c277df6e7d50)

## Summary by Sourcery

Bug 修复：
- 通过访问组件中的正确属性，正确更新网络配置表单值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly update network configuration form values by accessing the correct property in the component.

</details>