### PR TITLE
refactor: 即刻起逐出piscina

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "dependencies": {
     "@ffmpeg.wasm/core-mt": "^0.13.2",
     "express": "^5.0.0",
-    "piscina": "^4.7.0",
     "silk-wasm": "^3.6.1",
     "ws": "^8.18.0"
   }

--- a/src/common/audio-worker.ts
+++ b/src/common/audio-worker.ts
@@ -1,9 +1,20 @@
 import { encode } from 'silk-wasm';
+import { parentPort } from 'worker_threads';
 
 export interface EncodeArgs {
     input: ArrayBufferView | ArrayBuffer
     sampleRate: number
 }
-export default async ({ input, sampleRate }: EncodeArgs) => {
+export function recvTask<T>(cb: (taskData: T) => Promise<unknown>) {
+    parentPort?.on('message', async (taskData: T) => {
+        try {
+            let ret = await cb(taskData);
+            parentPort?.postMessage(ret);
+        } catch (error: unknown) {
+            parentPort?.postMessage({ error: (error as Error).message });
+        }
+    });
+}
+recvTask<EncodeArgs>(async ({ input, sampleRate }) => {
     return await encode(input, sampleRate);
-};
+});

--- a/src/common/ffmpeg.ts
+++ b/src/common/ffmpeg.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Piscina from 'piscina';
 import { VideoInfo } from './video';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { runTask } from './worker';
 
 type EncodeArgs = {
     method: 'extractThumbnail' | 'convertFile' | 'convert' | 'getVideoInfo';
@@ -9,42 +11,26 @@ type EncodeArgs = {
 
 type EncodeResult = any;
 
-async function getWorkerPath() {
-    return new URL(/* @vite-ignore */ './ffmpeg-worker.mjs', import.meta.url).href;
+function getWorkerPath() {
+    return path.join(path.dirname(fileURLToPath(import.meta.url)), './ffmpeg-worker.mjs');
 }
 
 export class FFmpegService {
     public static async extractThumbnail(videoPath: string, thumbnailPath: string): Promise<void> {
-        const piscina = new Piscina<EncodeArgs, EncodeResult>({
-            filename: await getWorkerPath(),
-        });
-        await piscina.run({ method: 'extractThumbnail', args: [videoPath, thumbnailPath] });
-        await piscina.destroy();
+        await runTask<EncodeArgs, EncodeResult>(getWorkerPath(), { method: 'extractThumbnail', args: [videoPath, thumbnailPath] });
     }
 
     public static async convertFile(inputFile: string, outputFile: string, format: string): Promise<void> {
-        const piscina = new Piscina<EncodeArgs, EncodeResult>({
-            filename: await getWorkerPath(),
-        });
-        await piscina.run({ method: 'convertFile', args: [inputFile, outputFile, format] });
-        await piscina.destroy();
+        await runTask<EncodeArgs, EncodeResult>(getWorkerPath(), { method: 'convertFile', args: [inputFile, outputFile, format] });
     }
 
     public static async convert(filePath: string, pcmPath: string): Promise<Buffer> {
-        const piscina = new Piscina<EncodeArgs, EncodeResult>({
-            filename: await getWorkerPath(),
-        });
-        const result = await piscina.run({ method: 'convert', args: [filePath, pcmPath] });
-        await piscina.destroy();
+        const result = await runTask<EncodeArgs, EncodeResult>(getWorkerPath(), { method: 'convert', args: [filePath, pcmPath] });
         return result;
     }
 
     public static async getVideoInfo(videoPath: string, thumbnailPath: string): Promise<VideoInfo> {
-        const piscina = new Piscina<EncodeArgs, EncodeResult>({
-            filename: await getWorkerPath(),
-        });
-        const result = await piscina.run({ method: 'getVideoInfo', args: [videoPath, thumbnailPath] });
-        await piscina.destroy();
+        const result = await await runTask<EncodeArgs, EncodeResult>(getWorkerPath(), { method: 'getVideoInfo', args: [videoPath, thumbnailPath] });
         return result;
     }
 }

--- a/src/common/worker.ts
+++ b/src/common/worker.ts
@@ -1,0 +1,29 @@
+import { Worker } from 'worker_threads';
+
+export async function runTask<T, R>(workerScript: string, taskData: T): Promise<R> {
+    let worker = new Worker(workerScript);
+    try {
+        return await new Promise<R>((resolve, reject) => {
+            worker.on('message', (result: R) => {
+                resolve(result);
+            });
+
+            worker.on('error', (error) => {
+                reject(new Error(`Worker error: ${error.message}`));
+            });
+
+            worker.on('exit', (code) => {
+                if (code !== 0) {
+                    reject(new Error(`Worker stopped with exit code ${code}`));
+                }
+            });
+            worker.postMessage(taskData);
+        });
+    } catch (error: unknown) {
+        throw new Error(`Failed to run task: ${(error as Error).message}`);
+    } finally {
+        // Ensure the worker is terminated after the promise is settled
+        worker.terminate();
+    }
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,8 +8,7 @@ const external = [
     'silk-wasm',
     'ws',
     'express',
-    '@ffmpeg.wasm/core-mt',
-    'piscina'
+    '@ffmpeg.wasm/core-mt'
 ];
 const nodeModules = [...builtinModules, builtinModules.map((m) => `node:${m}`)].flat();
 


### PR DESCRIPTION
好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

重构项目，移除 `piscina` 库，转而使用原生 worker 线程，以提高性能并减少依赖。此更改涉及修改 FFmpeg 和音频处理服务，以使用新的 worker 线程实现。

增强功能：
- 将 Piscina 替换为原生 worker 线程，以提高性能并减少依赖。

构建：
- 从项目的依赖项中移除 `piscina`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the project to remove the `piscina` library and instead use native worker threads for improved performance and reduced dependencies. This change involves modifying the FFmpeg and audio processing services to use the new worker thread implementation.

Enhancements:
- Replaces Piscina with native worker threads for improved performance and reduced dependencies.

Build:
- Removes `piscina` from the project's dependencies.

</details>