### PR TITLE
refactor: express-> hono

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ajv": "^8.13.0",
     "async-mutex": "^0.5.0",
     "commander": "^13.0.0",
+    "compressing": "^1.10.1",
     "cors": "^2.8.5",
     "esbuild": "0.25.0",
     "eslint": "^9.14.0",
@@ -54,14 +55,15 @@
     "image-size": "^1.1.1",
     "json5": "^2.2.3",
     "multer": "^1.4.5-lts.1",
+    "napcat.protobuf": "^1.1.3",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.13.0",
     "vite": "^6.0.1",
     "vite-plugin-cp": "^4.0.8",
     "vite-tsconfig-paths": "^5.1.0",
-    "napcat.protobuf": "^1.1.3",
-    "winston": "^3.17.0",
-    "compressing": "^1.10.1"
+    "hono": "^4.7.2",
+    "@hono/node-server": "^1.13.8",
+    "winston": "^3.17.0"
   },
   "dependencies": {
     "@ffmpeg.wasm/core-mt": "^0.13.2",

--- a/src/onebot/network/http-server.ts
+++ b/src/onebot/network/http-server.ts
@@ -1,19 +1,17 @@
 import { OB11EmitEventContent, OB11NetworkReloadType } from './index';
-import express, { Express, NextFunction, Request, Response } from 'express';
-import http from 'http';
+import { Context, Hono, Next } from 'hono';
 import { NapCatCore } from '@/core';
 import { OB11Response } from '@/onebot/action/OneBotAction';
 import { ActionMap } from '@/onebot/action';
-import cors from 'cors';
+import { cors } from 'hono/cors';
 import { HttpServerConfig } from '@/onebot/config/config';
 import { NapCatOneBot11Adapter } from '@/onebot';
 import { IOB11NetworkAdapter } from '@/onebot/network/adapter';
-import json5 from 'json5';
-import { isFinished } from 'on-finished';
-import typeis from 'type-is';
+import { serve } from '@hono/node-server';
+
 export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig> {
-    private app: Express | undefined;
-    private server: http.Server | undefined;
+    private app: Hono | undefined;
+    private server: ReturnType<typeof serve> | undefined;
 
     constructor(name: string, config: HttpServerConfig, core: NapCatCore, obContext: NapCatOneBot11Adapter, actions: ActionMap) {
         super(name, config, core, obContext, actions);
@@ -30,14 +28,11 @@ export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig>
                 this.core.context.logger.logError('Cannot open a closed HTTP server');
                 return;
             }
-            if (!this.isEnable) {
-                this.initializeServer();
-                this.isEnable = true;
-            }
+            this.initializeServer();
+            this.isEnable = true;
         } catch (e) {
             this.core.context.logger.logError(`[OneBot] [HTTP Server Adapter] Boot Error: ${e}`);
         }
-
     }
 
     async close() {
@@ -46,99 +41,61 @@ export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig>
         this.app = undefined;
     }
 
-
     private initializeServer() {
-        this.app = express();
-        this.server = http.createServer(this.app);
-
+        this.app = new Hono();
         this.app.use(cors());
-        this.app.use(express.urlencoded({ extended: true, limit: '5000mb' }));
-
-        this.app.use((req, res, next) => {
-            if (isFinished(req)) {
-                next();
-                return;
-            }
-            if (!typeis.hasBody(req)) {
-                next();
-                return;
-            }
-            // 兼容处理没有带content-type的请求
-            req.headers['content-type'] = 'application/json';
-            let rawData = '';
-            req.on('data', (chunk) => {
-                rawData += chunk;
-            });
-            req.on('end', () => {
-                try {
-                    req.body = { ...json5.parse(rawData || '{}'), ...req.body };
-                    next();
-                } catch {
-                    return res.status(400).send('Invalid JSON');
-                }
-                return;
-            });
-            req.on('error', () => {
-                return res.status(400).send('Invalid JSON');
-            });
+        this.app.use(async (c, next) => this.authorize(this.config.token, c, next));
+        this.app.use(async (c) => {
+            await this.handleRequest(c);
         });
-        //@ts-expect-error authorize
-        this.app.use((req, res, next) => this.authorize(this.config.token, req, res, next));
-        this.app.use(async (req, res) => {
-            await this.handleRequest(req, res);
-        });
-        this.server.listen(this.config.port, () => {
-            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Start On Port ${this.config.port}`);
+        this.server = serve({
+            fetch: this.app.fetch,
+            port: this.config.port,
         });
     }
 
-    private authorize(token: string | undefined, req: Request, res: Response, next: NextFunction) {
-        if (!token || token.length == 0) return next();//客户端未设置密钥
-        const HeaderClientToken = req.headers.authorization?.split('Bearer ').pop() || '';
-        const QueryClientToken = req.query['access_token'];
-        const ClientToken = typeof (QueryClientToken) === 'string' && QueryClientToken !== '' ? QueryClientToken : HeaderClientToken;
-        if (ClientToken === token) {
+    private authorize(token: string | undefined, c: Context, next: Next) {
+        if (!token || token.length === 0) return next(); // 客户端未设置密钥
+        const headerClientToken = c.req.header('authorization')?.split('Bearer ').pop() || '';
+        const queryClientToken = c.req.query('access_token');
+        const clientToken = typeof queryClientToken === 'string' && queryClientToken !== '' ? queryClientToken : headerClientToken;
+        if (clientToken === token) {
             return next();
-        } else {
-            return res.status(403).send(JSON.stringify({ message: 'token verify failed!' }));
         }
+        c.status(403);
+        c.json({ message: 'token verify failed!' });
+        return;
     }
 
-    async httpApiRequest(req: Request, res: Response) {
-        let payload = req.body;
-        if (req.method == 'get') {
-            payload = req.query;
-        } else if (req.query) {
-            payload = { ...req.body, ...req.query };
-        }
-        if (req.path === '' || req.path === '/') {
+    async httpApiRequest(c: Context) {
+        const payload = await c.req.json();
+        if (c.req.path === '' || c.req.path === '/') {
             const hello = OB11Response.ok({});
             hello.message = 'NapCat4 Is Running';
-            return res.json(hello);
+            return c.json(hello);
         }
-        const actionName = req.path.split('/')[1];
+        const actionName = c.req.path.split('/')[1];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const action = this.actions.get(actionName as any);
         if (action) {
             try {
                 const result = await action.handle(payload, this.name, this.config);
-                return res.json(result);
+                return c.json(result);
             } catch (error: unknown) {
-                return res.json(OB11Response.error((error as Error)?.stack?.toString() || (error as Error)?.message || 'Error Handle', 200));
+                return c.json(OB11Response.error((error as Error)?.stack?.toString() || (error as Error)?.message || 'Error Handle', 200));
             }
         } else {
-            return res.json(OB11Response.error('不支持的Api ' + actionName, 200));
+            return c.json(OB11Response.error('不支持的Api ' + actionName, 200));
         }
     }
 
-    async handleRequest(req: Request, res: Response) {
+    async handleRequest(c: Context) {
         if (!this.isEnable) {
             this.core.context.logger.log('[OneBot] [HTTP Server Adapter] Server is closed');
-            res.json(OB11Response.error('Server is closed', 200));
+            c.json(OB11Response.error('Server is closed', 200));
             return;
         }
-        this.httpApiRequest(req, res);
-        return;
+        await this.httpApiRequest(c);
     }
 
     async reload(newConfig: HttpServerConfig) {


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构项目，使用 Hono 代替 Express 来处理 HTTP 请求和 WebSocket 连接。此更改包括在 HTTP 服务器适配器中使用 Hono 替换 Express，并更新 WebSocket 服务器适配器以与 Hono 集成。此外，HTTP 服务器 SSE 适配器已更新为与 Hono 兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the project to use Hono instead of Express for handling HTTP requests and WebSocket connections. This change involves replacing Express with Hono in the HTTP server adapter and updating the WebSocket server adapter to integrate with Hono. Additionally, the HTTP server SSE adapter is updated to be compatible with Hono.

</details>