### PR TITLE
feat: 额外返回原msgSeq条目

### DIFF
--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -809,6 +809,7 @@ export class OneBotMsgApi {
             message_id: msg.id!,
             message_seq: msg.id!,
             real_id: msg.id!,
+            real_seq: msg.msgSeq,
             message_type: msg.chatType == ChatType.KCHATTYPEGROUP ? 'group' : 'private',
             sender: {
                 user_id: +(msg.senderUin ?? 0),


### PR DESCRIPTION
resolve #855

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

新功能：
- 在消息 API 响应中添加了 `real_seq` 字段，其中包含原始消息序列号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Adds the `real_seq` field to the message API response, containing the original message sequence number.

</details>