### PR TITLE
fix: isReverseOrder

### DIFF
--- a/src/onebot/action/go-cqhttp/GetFriendMsgHistory.ts
+++ b/src/onebot/action/go-cqhttp/GetFriendMsgHistory.ts
@@ -34,7 +34,7 @@ export default class GetFriendMsgHistory extends OneBotAction<Payload, Response>
         const hasMessageSeq = !payload.message_seq ? !!payload.message_seq : !(payload.message_seq?.toString() === '' || payload.message_seq?.toString() === '0');
         const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
         const msgList = hasMessageSeq ?
-            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, isReverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
         if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
         //翻转消息
         if (isReverseOrder) msgList.reverse();

--- a/src/onebot/action/go-cqhttp/GetFriendMsgHistory.ts
+++ b/src/onebot/action/go-cqhttp/GetFriendMsgHistory.ts
@@ -13,7 +13,7 @@ const SchemaData = z.object({
     user_id: z.union([z.number(), z.string()]),
     message_seq: z.union([z.number(), z.string()]).optional(),
     count: z.union([z.number(), z.string()]).default(20),
-    reverseOrder: z.union([z.boolean(), z.string()]).optional()
+    reverseOrder: z.boolean().default(false)
 });
 
 
@@ -26,18 +26,14 @@ export default class GetFriendMsgHistory extends OneBotAction<Payload, Response>
     async _handle(payload: Payload, _adapter: string, config: NetworkAdapterConfig): Promise<Response> {
         //处理参数
         const uid = await this.core.apis.UserApi.getUidByUinV2(payload.user_id.toString());
-
-        const isReverseOrder = typeof payload.reverseOrder === 'string' ? payload.reverseOrder === 'true' : !!payload.reverseOrder;
         if (!uid) throw new Error(`记录${payload.user_id}不存在`);
         const friend = await this.core.apis.FriendApi.isBuddy(uid);
         const peer = { chatType: friend ? ChatType.KCHATTYPEC2C : ChatType.KCHATTYPETEMPC2CFROMGROUP, peerUid: uid };
         const hasMessageSeq = !payload.message_seq ? !!payload.message_seq : !(payload.message_seq?.toString() === '' || payload.message_seq?.toString() === '0');
         const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
         const msgList = hasMessageSeq ?
-            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, isReverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, payload.reverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
         if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
-        //翻转消息
-        if (isReverseOrder) msgList.reverse();
         //转换序号
         await Promise.all(msgList.map(async msg => {
             msg.id = MessageUnique.createUniqueMsgId({ guildId: '', chatType: msg.chatType, peerUid: msg.peerUid }, msg.msgId);

--- a/src/onebot/action/go-cqhttp/GetGroupMsgHistory.ts
+++ b/src/onebot/action/go-cqhttp/GetGroupMsgHistory.ts
@@ -14,7 +14,7 @@ const SchemaData = z.object({
     group_id: z.union([z.number(), z.string()]),
     message_seq: z.union([z.number(), z.string()]).optional(),
     count: z.union([z.number(), z.string()]).default(20),
-    reverseOrder: z.union([z.boolean(), z.string()]).optional()
+    reverseOrder: z.boolean().default(false)
 });
 
 
@@ -26,17 +26,13 @@ export default class GoCQHTTPGetGroupMsgHistory extends OneBotAction<Payload, Re
     override payloadSchema = SchemaData;
 
     async _handle(payload: Payload, _adapter: string, config: NetworkAdapterConfig): Promise<Response> {
-        //处理参数
-        const isReverseOrder = typeof payload.reverseOrder === 'string' ? payload.reverseOrder === 'true' : !!payload.reverseOrder;
         const peer: Peer = { chatType: ChatType.KCHATTYPEGROUP, peerUid: payload.group_id.toString() };
         const hasMessageSeq = !payload.message_seq ? !!payload.message_seq : !(payload.message_seq?.toString() === '' || payload.message_seq?.toString() === '0');
         //拉取消息
         const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
         const msgList = hasMessageSeq ?
-            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, isReverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, payload.reverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
         if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
-        //翻转消息
-        if (isReverseOrder) msgList.reverse();
         //转换序号
         await Promise.all(msgList.map(async msg => {
             msg.id = MessageUnique.createUniqueMsgId({ guildId: '', chatType: msg.chatType, peerUid: msg.peerUid }, msg.msgId);

--- a/src/onebot/action/go-cqhttp/GetGroupMsgHistory.ts
+++ b/src/onebot/action/go-cqhttp/GetGroupMsgHistory.ts
@@ -33,7 +33,7 @@ export default class GoCQHTTPGetGroupMsgHistory extends OneBotAction<Payload, Re
         //拉取消息
         const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
         const msgList = hasMessageSeq ?
-            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+            (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, isReverseOrder)).msgList : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
         if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
         //翻转消息
         if (isReverseOrder) msgList.reverse();


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了消息历史记录检索问题，通过在好友和群组消息历史记录方法中添加对 `isReverseOrder` 参数的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed message history retrieval by adding support for the isReverseOrder parameter in both friend and group message history methods

</details>