### PR TITLE
fix: temp_source

### DIFF
--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -907,10 +907,10 @@ export class OneBotMsgApi {
             const member = await this.core.apis.GroupApi.getGroupMember(msg.peerUin, msg.senderUin);
             resMsg.group_id = parseInt(ret.tmpChatInfo!.groupCode);
             resMsg.sender.nickname = member?.nick ?? member?.cardName ?? '临时会话';
-            resMsg.temp_source = resMsg.group_id;
+            resMsg.temp_source = 0;
         } else {
             resMsg.group_id = 284840486;
-            resMsg.temp_source = resMsg.group_id;
+            resMsg.temp_source = 0;
             resMsg.sender.nickname = '临时会话';
         }
     }


### PR DESCRIPTION
fix #970

# 修复内容
将 `temp_source` 字段从 `group_id` 修正为 0，以符合 [`Post_Message_TempSource`](https://docs.go-cqhttp.org/reference/data_struct.html#post-message-tempsource) 枚举定义（0 表示群聊）。
## 影响范围
该变更会影响所有临时会话消息的 `temp_source` 字段，之前该字段错误地为群号，现在为固定值 0。
## 是否为破坏性变更（Breaking Change）
是。如果下游依赖了错误的 `temp_source` 行为（即等于群号），请注意兼容。

# What’s Changed
Set `temp_source` to 0 (group chat) instead of `group_id`, to comply with [`Post_Message_TempSource`](https://docs.go-cqhttp.org/reference/data_struct.html#post-message-tempsource) enum.
## Breaking Change?
Yes. If any downstream code relies on the previous (incorrect) behavior, please update accordingly.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修正了临时聊天场景中的 `temp_source` 赋值，使其始终设置为 0，无论群组上下文如何。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the temp_source assignment in temporary chat scenarios to always set it to 0, regardless of the group context

</details>