### PR TITLE
feat: 消息上报Url重构

### DIFF
--- a/src/core/apis/file.ts
+++ b/src/core/apis/file.ts
@@ -64,6 +64,7 @@ export class NTQQFileApi {
     }
 
     async getFileUrl(chatType: ChatType, peer: string, fileUUID?: string, file10MMd5?: string | undefined) {
+        if (this.core.apis.PacketApi.available) {
             try {
                 if (chatType === ChatType.KCHATTYPEGROUP && fileUUID) {
                     return this.core.apis.PacketApi.pkt.operation.GetGroupFileUrl(+peer, fileUUID);

--- a/src/core/apis/file.ts
+++ b/src/core/apis/file.ts
@@ -63,6 +63,73 @@ export class NTQQFileApi {
         }
     }
 
+    async getFileUrl(chatType: ChatType, peer: string, fileUUID?: string, file10MMd5?: string | undefined) {
+            try {
+                if (chatType === ChatType.KCHATTYPEGROUP && fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetGroupFileUrl(+peer, fileUUID);
+                } else if (file10MMd5 && fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetPrivateFileUrl(peer, fileUUID, file10MMd5);
+                }
+            } catch (error) {
+                this.context.logger.logError('获取文件URL失败', (error as Error).message);
+            }
+        }
+        throw new Error('fileUUID or file10MMd5 is undefined');
+    }
+
+    async getPttUrl(chatType: ChatType, peer: string, fileUUID?: string) {
+        if (this.core.apis.PacketApi.available) {
+            try {
+                if (chatType === ChatType.KCHATTYPEGROUP && fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetGroupPttUrl(+peer, {
+                        fileUuid: fileUUID,
+                        storeId: 1,
+                        uploadTime: 0,
+                        ttl: 0,
+                        subType: 0,
+                    });
+                } else if (fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetPttUrl(peer, {
+                        fileUuid: fileUUID,
+                        storeId: 1,
+                        uploadTime: 0,
+                        ttl: 0,
+                        subType: 0,
+                    });
+                }
+            } catch (error) {
+                this.context.logger.logError('获取文件URL失败', (error as Error).message);
+            }
+        }
+        throw new Error('packet cant get ptt url');
+    }
+
+    async getVideoUrlPakcet(chatType: ChatType, peer: string, fileUUID?: string) {
+        if (this.core.apis.PacketApi.available) {
+            try {
+                if (chatType === ChatType.KCHATTYPEGROUP && fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetGroupVideoUrl(+peer, {
+                        fileUuid: fileUUID,
+                        storeId: 1,
+                        uploadTime: 0,
+                        ttl: 0,
+                        subType: 0,
+                    });
+                } else if (fileUUID) {
+                    return this.core.apis.PacketApi.pkt.operation.GetVideoUrl(peer, {
+                        fileUuid: fileUUID,
+                        storeId: 1,
+                        uploadTime: 0,
+                        ttl: 0,
+                        subType: 0,
+                    });
+                }
+            } catch (error) {
+                this.context.logger.logError('获取文件URL失败', (error as Error).message);
+            }
+        }
+        throw new Error('packet cant get ptt url');
+    }
 
     async copyFile(filePath: string, destPath: string) {
         await this.core.util.copyFile(filePath, destPath);

--- a/src/core/apis/file.ts
+++ b/src/core/apis/file.ts
@@ -129,7 +129,7 @@ export class NTQQFileApi {
                 this.context.logger.logError('获取文件URL失败', (error as Error).message);
             }
         }
-        throw new Error('packet cant get ptt url');
+        throw new Error('packet cant get video url');
     }
 
     async copyFile(filePath: string, destPath: string) {

--- a/src/core/apis/file.ts
+++ b/src/core/apis/file.ts
@@ -105,7 +105,7 @@ export class NTQQFileApi {
         throw new Error('packet cant get ptt url');
     }
 
-    async getVideoUrlPakcet(chatType: ChatType, peer: string, fileUUID?: string) {
+    async getVideoUrlPacket(chatType: ChatType, peer: string, fileUUID?: string) {
         if (this.core.apis.PacketApi.available) {
             try {
                 if (chatType === ChatType.KCHATTYPEGROUP && fileUUID) {

--- a/src/core/apis/msg.ts
+++ b/src/core/apis/msg.ts
@@ -71,6 +71,7 @@ export class NTQQMsgApi {
     async queryMsgsWithFilterExWithSeq(peer: Peer, msgSeq: string) {
         return await this.context.session.getMsgService().queryMsgsWithFilterEx('0', '0', msgSeq, {
             chatInfo: peer,
+            //searchFields: 3,
             filterMsgType: [],
             filterSendersUid: [],
             filterMsgToTime: '0',
@@ -84,6 +85,7 @@ export class NTQQMsgApi {
         return await this.context.session.getMsgService().queryMsgsWithFilterEx('0', '0', msgSeq, {
             chatInfo: peer,
             filterMsgType: [],
+            //searchFields: 3,
             filterSendersUid: SendersUid,
             filterMsgToTime: MsgTime,
             filterMsgFromTime: MsgTime,
@@ -100,6 +102,7 @@ export class NTQQMsgApi {
             filterMsgToTime: '0',
             filterMsgFromTime: '0',
             isReverseOrder: false,
+            //searchFields: 3,
             isIncludeCurrent: true,
             pageLimit: 1,
         });
@@ -110,6 +113,7 @@ export class NTQQMsgApi {
             filterMsgType: [],
             filterSendersUid: [],
             filterMsgToTime: '0',
+            //searchFields: 3,
             filterMsgFromTime: '0',
             isReverseOrder: true,
             isIncludeCurrent: true,
@@ -128,6 +132,7 @@ export class NTQQMsgApi {
             chatInfo: peer,//此处为Peer 为关键查询参数 没有啥也没有 by mlik iowa
             filterMsgType: [],
             filterSendersUid: [],
+            //searchFields: 3,
             filterMsgToTime: filterMsgToTime,
             filterMsgFromTime: filterMsgFromTime,
             isReverseOrder: false,
@@ -142,6 +147,7 @@ export class NTQQMsgApi {
             chatInfo: peer,
             filterMsgType: [],
             filterSendersUid: SendersUid,
+            //searchFields: 3,
             filterMsgToTime: '0',
             filterMsgFromTime: '0',
             isReverseOrder: true,

--- a/src/core/packet/context/operationContext.ts
+++ b/src/core/packet/context/operationContext.ts
@@ -124,12 +124,41 @@ export class PacketOperationContext {
         return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
     }
 
+    async GetPttUrl(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>) {
+        const req = trans.DownloadPtt.build(selfUid, node);
+        const resp = await this.context.client.sendOidbPacket(req, true);
+        const res = trans.DownloadImage.parse(resp);
+        return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
+    }
+
+    async GetVideoUrl(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>) {
+        const req = trans.DownloadVideo.build(selfUid, node);
+        const resp = await this.context.client.sendOidbPacket(req, true);
+        const res = trans.DownloadImage.parse(resp);
+        return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
+    }
+
     async GetGroupImageUrl(groupUin: number, node: NapProtoEncodeStructType<typeof IndexNode>) {
         const req = trans.DownloadGroupImage.build(groupUin, node);
         const resp = await this.context.client.sendOidbPacket(req, true);
         const res = trans.DownloadImage.parse(resp);
         return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
     }
+
+    async GetGroupPttUrl(groupUin: number, node: NapProtoEncodeStructType<typeof IndexNode>) {
+        const req = trans.DownloadGroupPtt.build(groupUin, node);
+        const resp = await this.context.client.sendOidbPacket(req, true);
+        const res = trans.DownloadImage.parse(resp);
+        return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
+    }
+
+    async GetGroupVideoUrl(groupUin: number, node: NapProtoEncodeStructType<typeof IndexNode>) {
+        const req = trans.DownloadGroupVideo.build(groupUin, node);
+        const resp = await this.context.client.sendOidbPacket(req, true);
+        const res = trans.DownloadImage.parse(resp);
+        return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
+    }
+
 
     async ImageOCR(imgUrl: string) {
         const req = trans.ImageOCR.build(imgUrl);
@@ -154,7 +183,7 @@ export class PacketOperationContext {
 
     private async SendPreprocess(msg: PacketMsg[], groupUin: number = 0) {
         const ps = msg.map((m) => {
-            return m.msg.map(async(e) => {
+            return m.msg.map(async (e) => {
                 if (e instanceof PacketMsgReplyElement && !e.targetElems) {
                     this.context.logger.debug(`Cannot find reply element's targetElems, prepare to fetch it...`);
                     if (!e.targetPeer?.peerUid) {
@@ -222,18 +251,12 @@ export class PacketOperationContext {
         const res = trans.DownloadGroupFile.parse(resp);
         return `https://${res.download.downloadDns}/ftn_handler/${Buffer.from(res.download.downloadUrl).toString('hex')}/?fname=`;
     }
+
     async GetPrivateFileUrl(self_id: string, fileUUID: string, md5: string) {
         const req = trans.DownloadPrivateFile.build(self_id, fileUUID, md5);
         const resp = await this.context.client.sendOidbPacket(req, true);
         const res = trans.DownloadPrivateFile.parse(resp);
         return `http://${res.body?.result?.server}:${res.body?.result?.port}${res.body?.result?.url?.slice(8)}&isthumb=0`;
-    }
-
-    async GetGroupPttUrl(groupUin: number, node: NapProtoEncodeStructType<typeof IndexNode>) {
-        const req = trans.DownloadGroupPtt.build(groupUin, node);
-        const resp = await this.context.client.sendOidbPacket(req, true);
-        const res = trans.DownloadGroupPtt.parse(resp);
-        return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
     }
 
     async GetMiniAppAdaptShareInfo(param: MiniAppReqParams) {

--- a/src/core/packet/context/operationContext.ts
+++ b/src/core/packet/context/operationContext.ts
@@ -127,14 +127,14 @@ export class PacketOperationContext {
     async GetPttUrl(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>) {
         const req = trans.DownloadPtt.build(selfUid, node);
         const resp = await this.context.client.sendOidbPacket(req, true);
-        const res = trans.DownloadImage.parse(resp);
+        const res = trans.DownloadPtt.parse(resp);
         return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
     }
 
     async GetVideoUrl(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>) {
         const req = trans.DownloadVideo.build(selfUid, node);
         const resp = await this.context.client.sendOidbPacket(req, true);
-        const res = trans.DownloadImage.parse(resp);
+        const res = trans.DownloadVideo.parse(resp);
         return `https://${res.download.info.domain}${res.download.info.urlPath}${res.download.rKeyParam}`;
     }
 

--- a/src/core/packet/transformer/highway/DownloadGroupVideo.ts
+++ b/src/core/packet/transformer/highway/DownloadGroupVideo.ts
@@ -1,0 +1,50 @@
+import * as proto from '@/core/packet/transformer/proto';
+import { NapProtoEncodeStructType, NapProtoMsg } from '@napneko/nap-proto-core';
+import { OidbPacket, PacketTransformer } from '@/core/packet/transformer/base';
+import OidbBase from '@/core/packet/transformer/oidb/oidbBase';
+import { IndexNode } from '@/core/packet/transformer/proto';
+
+class DownloadGroupVideo extends PacketTransformer<typeof proto.NTV2RichMediaResp> {
+    constructor() {
+        super();
+    }
+
+    build(groupUin: number, node: NapProtoEncodeStructType<typeof IndexNode>): OidbPacket {
+        const body = new NapProtoMsg(proto.NTV2RichMediaReq).encode({
+            reqHead: {
+                common: {
+                    requestId: 1,
+                    command: 200
+                },
+                scene: {
+                    requestType: 2,
+                    businessType: 2,
+                    sceneType: 2,
+                    group: {
+                        groupUin: groupUin
+                    }
+                },
+                client: {
+                    agentType: 2,
+                }
+            },
+            download: {
+                node: node,
+                download: {
+                    video: {
+                        busiType: 0,
+                        sceneType: 0
+                    }
+                }
+            }
+        });
+        return OidbBase.build(0x11EA, 200, body, true, false);
+    }
+
+    parse(data: Buffer) {
+        const oidbBody = OidbBase.parse(data).body;
+        return new NapProtoMsg(proto.NTV2RichMediaResp).decode(oidbBody);
+    }
+}
+
+export default new DownloadGroupVideo();

--- a/src/core/packet/transformer/highway/DownloadPtt.ts
+++ b/src/core/packet/transformer/highway/DownloadPtt.ts
@@ -1,0 +1,51 @@
+import * as proto from '@/core/packet/transformer/proto';
+import { NapProtoEncodeStructType, NapProtoMsg } from '@napneko/nap-proto-core';
+import { OidbPacket, PacketTransformer } from '@/core/packet/transformer/base';
+import OidbBase from '@/core/packet/transformer/oidb/oidbBase';
+import { IndexNode } from '@/core/packet/transformer/proto';
+
+class DownloadPtt extends PacketTransformer<typeof proto.NTV2RichMediaResp> {
+    constructor() {
+        super();
+    }
+
+    build(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>): OidbPacket {
+        const body = new NapProtoMsg(proto.NTV2RichMediaReq).encode({
+            reqHead: {
+                common: {
+                    requestId: 1,
+                    command: 200
+                },
+                scene: {
+                    requestType: 1,
+                    businessType: 3,
+                    sceneType: 1,
+                    c2C: {
+                        accountType: 2,
+                        targetUid: selfUid
+                    },
+                },
+                client: {
+                    agentType: 2,
+                }
+            },
+            download: {
+                node: node,
+                download: {
+                    video: {
+                        busiType: 0,
+                        sceneType: 0
+                    }
+                }
+            }
+        });
+        return OidbBase.build(0x126D, 200, body, true, false);
+    }
+
+    parse(data: Buffer) {
+        const oidbBody = OidbBase.parse(data).body;
+        return new NapProtoMsg(proto.NTV2RichMediaResp).decode(oidbBody);
+    }
+}
+
+export default new DownloadPtt();

--- a/src/core/packet/transformer/highway/DownloadVideo.ts
+++ b/src/core/packet/transformer/highway/DownloadVideo.ts
@@ -1,0 +1,51 @@
+import * as proto from '@/core/packet/transformer/proto';
+import { NapProtoEncodeStructType, NapProtoMsg } from '@napneko/nap-proto-core';
+import { OidbPacket, PacketTransformer } from '@/core/packet/transformer/base';
+import OidbBase from '@/core/packet/transformer/oidb/oidbBase';
+import { IndexNode } from '@/core/packet/transformer/proto';
+
+class DownloadVideo extends PacketTransformer<typeof proto.NTV2RichMediaResp> {
+    constructor() {
+        super();
+    }
+
+    build(selfUid: string, node: NapProtoEncodeStructType<typeof IndexNode>): OidbPacket {
+        const body = new NapProtoMsg(proto.NTV2RichMediaReq).encode({
+            reqHead: {
+                common: {
+                    requestId: 1,
+                    command: 200
+                },
+                scene: {
+                    requestType: 2,
+                    businessType: 2,
+                    sceneType: 1,
+                    c2C: {
+                        accountType: 2,
+                        targetUid: selfUid
+                    },
+                },
+                client: {
+                    agentType: 2,
+                }
+            },
+            download: {
+                node: node,
+                download: {
+                    video: {
+                        busiType: 0,
+                        sceneType: 0
+                    }
+                }
+            }
+        });
+        return OidbBase.build(0x11E9, 200, body, true, false);
+    }
+
+    parse(data: Buffer) {
+        const oidbBody = OidbBase.parse(data).body;
+        return new NapProtoMsg(proto.NTV2RichMediaResp).decode(oidbBody);
+    }
+}
+
+export default new DownloadVideo();

--- a/src/core/packet/transformer/highway/index.ts
+++ b/src/core/packet/transformer/highway/index.ts
@@ -13,3 +13,6 @@ export { default as UploadPrivatePtt } from './UploadPrivatePtt';
 export { default as UploadPrivateVideo } from './UploadPrivateVideo';
 export { default as DownloadImage } from './DownloadImage';
 export { default as DownloadGroupImage } from './DownloadGroupImage';
+export { default as DownloadVideo } from './DownloadVideo';
+export { default as DownloadGroupVideo } from './DownloadGroupVideo';
+export { default as DownloadPtt } from './DownloadPtt';

--- a/src/core/services/NodeIKernelMsgService.ts
+++ b/src/core/services/NodeIKernelMsgService.ts
@@ -148,10 +148,11 @@ export interface NodeIKernelMsgService {
         msgList: RawMessage[]
     }>;
 
-    //@deprecated
-    getMsgs(peer: Peer, msgId: string, count: unknown, queryOrder: boolean): Promise<unknown>;
+    // getMsgService/getMsgs { chatType: 2, peerUid: '975206796', privilegeFlag: 336068800 } 0 20 true
+    getMsgs(peer: Peer & { privilegeFlag: number }, msgId: string, count: number, queryOrder: boolean): Promise<GeneralCallResult & {
+        msgList: RawMessage[]
+    }>;
 
-    //@deprecated
     getMsgsIncludeSelf(peer: Peer, msgId: string, count: number, queryOrder: boolean): Promise<GeneralCallResult & {
         msgList: RawMessage[]
     }>;

--- a/src/core/types/msg.ts
+++ b/src/core/types/msg.ts
@@ -508,7 +508,8 @@ export interface RawMessage {
  * 查询消息参数接口
  */
 export interface QueryMsgsParams {
-    chatInfo: Peer;
+    chatInfo: Peer & { privilegeFlag?: number };
+    //searchFields: number;
     filterMsgType: Array<{ type: NTMsgType, subType: Array<number> }>;
     filterSendersUid: string[];
     filterMsgFromTime: string;

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -385,7 +385,7 @@ export class OneBotMsgApi {
                 try {
                     pttUrl = await this.core.apis.FileApi.getPttUrl(msg.chatType, msg.peerUid, element.fileUuid);
                 } catch (e) {
-                    this.core.context.logger.logError('获取视频url失败', (e as Error).stack);
+                    this.core.context.logger.logError('获取语音url失败', (e as Error).stack);
                     pttUrl = element.filePath;
                 }
             } else {

--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -352,7 +352,7 @@ export class OneBotMsgApi {
             if (!videoDownUrl) {
                 if (this.core.apis.PacketApi.available) {
                     try {
-                        videoDownUrl = await this.core.apis.FileApi.getVideoUrlPakcet(msg.chatType, msg.peerUid, element.fileUuid);
+                        videoDownUrl = await this.core.apis.FileApi.getVideoUrlPacket(msg.chatType, msg.peerUid, element.fileUuid);
                     } catch (e) {
                         this.core.context.logger.logError('获取视频url失败', (e as Error).stack);
                         videoDownUrl = element.filePath;


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构并增强了跨各种聊天环境的不同文件类型的消息报告 URL 检索

**新特性:**

- 添加了用于检索不同聊天类型中的文件、语音消息和视频的 URL 的方法
- 实现了用于群聊和私聊的基于数据包的 URL 检索

**增强:**

- 改进了文件 URL 检索，具有更强大的错误处理能力
- 增加了对获取不同媒体类型的下载 URL 的支持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor and enhance message reporting URL retrieval for different file types across various chat contexts

New Features:
- Add methods to retrieve URLs for files, voice messages, and videos in different chat types
- Implement packet-based URL retrieval for group and private chats

Enhancements:
- Improve file URL retrieval with more robust error handling
- Add support for getting download URLs for different media types

</details>