### PR TITLE
增加抽象类，修改继承关系

### DIFF
--- a/src/onebot/event/notice/OB11BaseNoticeEvent.ts
+++ b/src/onebot/event/notice/OB11BaseNoticeEvent.ts
@@ -2,4 +2,5 @@ import { EventType, OneBotEvent } from '@/onebot/event/OneBotEvent';
 
 export abstract class OB11BaseNoticeEvent extends OneBotEvent {
     post_type = EventType.NOTICE;
+    abstract notice_type: string;
 }

--- a/src/onebot/event/request/OB11BaseRequestEvent.ts
+++ b/src/onebot/event/request/OB11BaseRequestEvent.ts
@@ -1,0 +1,6 @@
+import { EventType, OneBotEvent } from '../OneBotEvent';
+
+export abstract class OB11BaseRequestEvent extends OneBotEvent {
+    post_type = EventType.REQUEST;
+    abstract request_type: string;
+}

--- a/src/onebot/event/request/OB11BaseRequestEvent.ts
+++ b/src/onebot/event/request/OB11BaseRequestEvent.ts
@@ -1,6 +1,6 @@
 import { EventType, OneBotEvent } from '@/onebot/event/OneBotEvent';
 
 export abstract class OB11BaseRequestEvent extends OneBotEvent {
-    post_type = EventType.REQUEST;
+    readonly post_type = EventType.REQUEST;
     abstract request_type: string;
 }

--- a/src/onebot/event/request/OB11BaseRequestEvent.ts
+++ b/src/onebot/event/request/OB11BaseRequestEvent.ts
@@ -1,4 +1,4 @@
-import { EventType, OneBotEvent } from '../OneBotEvent';
+import { EventType, OneBotEvent } from '@/onebot/event/OneBotEvent';
 
 export abstract class OB11BaseRequestEvent extends OneBotEvent {
     post_type = EventType.REQUEST;

--- a/src/onebot/event/request/OB11FriendRequest.ts
+++ b/src/onebot/event/request/OB11FriendRequest.ts
@@ -1,9 +1,7 @@
-import { OB11BaseNoticeEvent } from '@/onebot/event/notice/OB11BaseNoticeEvent';
-import { EventType } from '@/onebot/event/OneBotEvent';
 import { NapCatCore } from '@/core';
+import { OB11BaseRequestEvent } from './OB11BaseRequestEvent';
 
-export class OB11FriendRequestEvent extends OB11BaseNoticeEvent {
-    override post_type = EventType.REQUEST;
+export class OB11FriendRequestEvent extends OB11BaseRequestEvent {
     request_type = 'friend';
 
     user_id: number;

--- a/src/onebot/event/request/OB11FriendRequest.ts
+++ b/src/onebot/event/request/OB11FriendRequest.ts
@@ -2,7 +2,7 @@ import { NapCatCore } from '@/core';
 import { OB11BaseRequestEvent } from './OB11BaseRequestEvent';
 
 export class OB11FriendRequestEvent extends OB11BaseRequestEvent {
-    request_type = 'friend';
+    override request_type = 'friend';
 
     user_id: number;
     comment: string;

--- a/src/onebot/event/request/OB11GroupRequest.ts
+++ b/src/onebot/event/request/OB11GroupRequest.ts
@@ -1,18 +1,18 @@
-import { OB11GroupNoticeEvent } from '@/onebot/event/notice/OB11GroupNoticeEvent';
-import { EventType } from '@/onebot/event/OneBotEvent';
 import { NapCatCore } from '@/core';
+import { OB11BaseRequestEvent } from './OB11BaseRequestEvent';
 
-export class OB11GroupRequestEvent extends OB11GroupNoticeEvent {
-    override post_type = EventType.REQUEST;
+export class OB11GroupRequestEvent extends OB11BaseRequestEvent {
     request_type = 'group';
 
-    override user_id: number;
+    group_id: number;
+    user_id: number;
     comment: string;
     flag: string;
     sub_type: string;
 
     constructor(core: NapCatCore, groupId: number, userId: number, sub_type: string, comment: string, flag: string) {
-        super(core, groupId, userId);
+        super(core);
+        this.group_id = groupId;
         this.user_id = userId;
         this.sub_type = sub_type;
         this.comment = comment;

--- a/src/onebot/event/request/OB11GroupRequest.ts
+++ b/src/onebot/event/request/OB11GroupRequest.ts
@@ -2,7 +2,7 @@ import { NapCatCore } from '@/core';
 import { OB11BaseRequestEvent } from './OB11BaseRequestEvent';
 
 export class OB11GroupRequestEvent extends OB11BaseRequestEvent {
-    override request_type = 'group';
+    override request_type: 'group' = 'group';
 
     group_id: number;
     user_id: number;

--- a/src/onebot/event/request/OB11GroupRequest.ts
+++ b/src/onebot/event/request/OB11GroupRequest.ts
@@ -2,7 +2,7 @@ import { NapCatCore } from '@/core';
 import { OB11BaseRequestEvent } from './OB11BaseRequestEvent';
 
 export class OB11GroupRequestEvent extends OB11BaseRequestEvent {
-    request_type = 'group';
+    override request_type = 'group';
 
     group_id: number;
     user_id: number;


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构事件类，引入抽象基类请求事件，并在基本通知事件中强制执行通知类型。

增强功能：
- 添加 `OB11BaseRequestEvent` 抽象类，以集中请求事件属性和 `post_type`
- 更新 `OB11GroupRequestEvent` 和 `OB11FriendRequestEvent` 以扩展 `OB11BaseRequestEvent` 并删除冗余继承
- 将抽象 `notice_type` 添加到 `OB11BaseNoticeEvent` 以强制执行通知子类型定义
- 调整群组和好友请求事件的构造函数和属性以使用新的基类

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor event classes by introducing an abstract base request event and enforcing notice types in the base notice event.

Enhancements:
- Add OB11BaseRequestEvent abstract class to centralize request event properties and post_type
- Update OB11GroupRequestEvent and OB11FriendRequestEvent to extend OB11BaseRequestEvent and remove redundant inheritance
- Add abstract notice_type to OB11BaseNoticeEvent to enforce notice subtype definitions
- Adjust constructors and properties for group and friend request events to use the new base class

</details>