### PR TITLE
feat: 隔离context传递 避免高并发干扰一个实例

### DIFF
--- a/src/onebot/action/go-cqhttp/SendForwardMsg.ts
+++ b/src/onebot/action/go-cqhttp/SendForwardMsg.ts
@@ -1,4 +1,4 @@
-import { normalize, SendMsgBase } from '@/onebot/action/msg/SendMsg';
+import { ContextMode, normalize, ReturnDataType, SendMsgBase } from '@/onebot/action/msg/SendMsg';
 import { OB11PostSendMsg } from '@/onebot/types';
 import { ActionName } from '@/onebot/action/router';
 
@@ -19,8 +19,14 @@ export class GoCQHTTPSendForwardMsg extends GoCQHTTPSendForwardMsgBase {
 }
 export class GoCQHTTPSendPrivateForwardMsg extends GoCQHTTPSendForwardMsgBase {
     override actionName = ActionName.GoCQHTTP_SendPrivateForwardMsg;
+    override async _handle(payload: OB11PostSendMsg): Promise<ReturnDataType> {
+        return this.base_handle(payload, ContextMode.Private);
+    }
 }
 
 export class GoCQHTTPSendGroupForwardMsg extends GoCQHTTPSendForwardMsgBase {
     override actionName = ActionName.GoCQHTTP_SendGroupForwardMsg;
+    override async _handle(payload: OB11PostSendMsg): Promise<ReturnDataType> {
+        return this.base_handle(payload, ContextMode.Group);
+    }
 }

--- a/src/onebot/action/group/SendGroupMsg.ts
+++ b/src/onebot/action/group/SendGroupMsg.ts
@@ -1,16 +1,18 @@
-import { ContextMode, SendMsgBase } from '@/onebot/action/msg/SendMsg';
+import { ContextMode, ReturnDataType, SendMsgBase } from '@/onebot/action/msg/SendMsg';
 import { ActionName, BaseCheckResult } from '@/onebot/action/router';
 import { OB11PostSendMsg } from '@/onebot/types';
 
 // 未检测参数
 class SendGroupMsg extends SendMsgBase {
     override actionName = ActionName.SendGroupMsg;
-    override contextMode: ContextMode = ContextMode.Group;
 
     protected override async check(payload: OB11PostSendMsg): Promise<BaseCheckResult> {
         delete payload.user_id;
         payload.message_type = 'group';
         return super.check(payload);
+    }
+    override async _handle(payload: OB11PostSendMsg): Promise<ReturnDataType> {
+        return this.base_handle(payload, ContextMode.Group);
     }
 }
 

--- a/src/onebot/action/msg/SendMsg.ts
+++ b/src/onebot/action/msg/SendMsg.ts
@@ -104,8 +104,6 @@ function getSpecialMsgNum(payload: OB11PostSendMsg, msgType: OB11MessageDataType
 }
 
 export class SendMsgBase extends OneBotAction<OB11PostSendMsg, ReturnDataType> {
-    contextMode = ContextMode.Normal;
-
     protected override async check(payload: OB11PostSendMsg): Promise<BaseCheckResult> {
         const messages = normalize(payload.message);
         const nodeElementLength = getSpecialMsgNum(payload, OB11MessageDataType.node);
@@ -117,12 +115,13 @@ export class SendMsgBase extends OneBotAction<OB11PostSendMsg, ReturnDataType> {
         }
         return { valid: true };
     }
-
     async _handle(payload: OB11PostSendMsg): Promise<ReturnDataType> {
-        this.contextMode = ContextMode.Normal;
-        if (payload.message_type === 'group') this.contextMode = ContextMode.Group;
-        if (payload.message_type === 'private') this.contextMode = ContextMode.Private;
-        const peer = await createContext(this.core, payload, this.contextMode);
+        return this.base_handle(payload);
+    }
+    async base_handle(payload: OB11PostSendMsg, contextMode: ContextMode = ContextMode.Normal): Promise<ReturnDataType> {
+        if (payload.message_type === 'group') contextMode = ContextMode.Group;
+        if (payload.message_type === 'private') contextMode = ContextMode.Private;
+        const peer = await createContext(this.core, payload, contextMode);
 
         const messages = normalize(
             payload.message,

--- a/src/onebot/action/msg/SendPrivateMsg.ts
+++ b/src/onebot/action/msg/SendPrivateMsg.ts
@@ -1,15 +1,17 @@
-import { ContextMode, SendMsgBase } from './SendMsg';
+import { ContextMode, ReturnDataType, SendMsgBase } from './SendMsg';
 import { ActionName, BaseCheckResult } from '@/onebot/action/router';
 import { OB11PostSendMsg } from '@/onebot/types';
 
 // 未检测参数
 class SendPrivateMsg extends SendMsgBase {
     override actionName = ActionName.SendPrivateMsg;
-    override contextMode: ContextMode = ContextMode.Private;
 
     protected override async check(payload: OB11PostSendMsg): Promise<BaseCheckResult> {
         payload.message_type = 'private';
         return super.check(payload);
+    }
+    override async _handle(payload: OB11PostSendMsg): Promise<ReturnDataType> {
+        return this.base_handle(payload, ContextMode.Private);
     }
 }
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

通过将 ContextMode 作为参数传递，而不是将其存储在 action 实例上，从而隔离 send-message action 中的上下文传播，防止高并发下的干扰。

增强功能：
- 重构 SendMsgBase 以移除其可变的 contextMode 属性，并引入一个 base_handle 方法，该方法接受每个调用的 ContextMode
- 更新所有 SendMsg 和 GoCQHTTP SendForwardMsg 处理程序，以使用显式的 ContextMode 参数委托给 base_handle

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate context propagation in send-message actions by passing ContextMode as a parameter rather than storing it on the action instance, preventing interference under high concurrency.

Enhancements:
- Refactor SendMsgBase to remove its mutable contextMode property and introduce a base_handle method that accepts ContextMode per call
- Update all SendMsg and GoCQHTTP SendForwardMsg handlers to delegate to base_handle with explicit ContextMode arguments

</details>