### PR TITLE
允许使用环境变量指定napcat工作路径。

### DIFF
--- a/src/common/path.ts
+++ b/src/common/path.ts
@@ -13,11 +13,15 @@ export class NapCatPathWrapper {
     constructor(mainPath: string = dirname(fileURLToPath(import.meta.url))) {
         this.binaryPath = mainPath;
         let writePath: string;
-        if (os.platform() === 'darwin') {
+
+        if (process.env['NAPCAT_WRITEPATH']) {
+            writePath = process.env['NAPCAT_WRITEPATH'];
+        } else if (os.platform() === 'darwin') {
             writePath = path.join(os.homedir(), 'Library', 'Application Support', 'QQ', 'NapCat');
         } else {
             writePath = this.binaryPath;
         }
+
         this.logsPath = path.join(writePath, 'logs');
         this.configPath = path.join(writePath, 'config');
         this.cachePath = path.join(writePath, 'cache');

--- a/src/common/path.ts
+++ b/src/common/path.ts
@@ -14,8 +14,8 @@ export class NapCatPathWrapper {
         this.binaryPath = mainPath;
         let writePath: string;
 
-        if (process.env['NAPCAT_WRITEPATH']) {
-            writePath = process.env['NAPCAT_WRITEPATH'];
+        if (process.env['NAPCAT_WORKDIR']) {
+            writePath = process.env['NAPCAT_WORKDIR'];
         } else if (os.platform() === 'darwin') {
             writePath = path.join(os.homedir(), 'Library', 'Application Support', 'QQ', 'NapCat');
         } else {


### PR DESCRIPTION
在系统中安装软件时，需要将软件本体与配置文件还有软件数据等部分分离。因此引入此环境变量，在保证配置文件路径的可配置性的同时，不影响普通用户在桌面端直接运行此软件。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

启用可配置写入路径，在回退到平台特定默认值之前检查 NAPCAT_WRITEPATH

新特性：
- 允许使用 NAPCAT_WRITEPATH 环境变量覆盖 NapCat 写入路径

增强功能：
- 保持默认写入路径行为：在 macOS 上使用 Application Support 目录，在其他地方使用二进制目录

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable configurable write path by checking NAPCAT_WRITEPATH before falling back to platform-specific defaults

New Features:
- Allow overriding NapCat write path using the NAPCAT_WRITEPATH environment variable

Enhancements:
- Keep default write path behavior: use Application Support directory on macOS and binary directory elsewhere

</details>