### PR TITLE
fix: fix missing host in onebot http-server listen

### DIFF
--- a/src/onebot/network/http-server.ts
+++ b/src/onebot/network/http-server.ts
@@ -88,7 +88,7 @@ export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig>
             await this.handleRequest(req, res);
         });
         this.server.listen(this.config.port, this.config.host, () => {
-            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Start On Port ${this.config.port}`);
+            this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Start On ${this.config.host}:${this.config.port}`);
         });
     }
 

--- a/src/onebot/network/http-server.ts
+++ b/src/onebot/network/http-server.ts
@@ -87,7 +87,7 @@ export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig>
         this.app.use(async (req, res) => {
             await this.handleRequest(req, res);
         });
-        this.server.listen(this.config.port, () => {
+        this.server.listen(this.config.port, this.config.host, () => {
             this.core.context.logger.log(`[OneBot] [HTTP Server Adapter] Start On Port ${this.config.port}`);
         });
     }


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 在 `OB11HttpServerAdapter` 中将 `config.host` 传递给 `server.listen`，以修复缺少主机绑定的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Pass `config.host` to `server.listen` in `OB11HttpServerAdapter` to fix missing host binding.

</details>