### PR TITLE
群系统消息（aka. 入群申请）

### DIFF
--- a/napcat.webui/src/const/ob_api/group.ts
+++ b/napcat.webui/src/const/ob_api/group.ts
@@ -24,9 +24,7 @@ const oneBotHttpApiGroup = {
   },
   '/get_group_system_msg': {
     description: '获取群系统消息',
-    request: z.object({
-      group_id: z.union([z.string(), z.number()]).describe('群号')
-    }),
+    request: z.object({}),
     response: baseResponseSchema.extend({
       data: z.object({
         InvitedRequest: z
@@ -37,6 +35,7 @@ const oneBotHttpApiGroup = {
                 invitor_uin: z.string().describe('邀请人 QQ 号'),
                 invitor_nick: z.string().describe('邀请人昵称'),
                 group_id: z.string().describe('群号'),
+                message: z.string().describe('入群回答'),
                 group_name: z.string().describe('群名称'),
                 checked: z.boolean().describe('是否已处理'),
                 actor: z.string().describe('处理人 QQ 号')
@@ -50,6 +49,7 @@ const oneBotHttpApiGroup = {
             requester_uin: z.string().describe('请求人 QQ 号'),
             requester_nick: z.string().describe('请求人昵称'),
             group_id: z.string().describe('群号'),
+            message: z.string().describe('入群回答'),
             group_name: z.string().describe('群名称'),
             checked: z.boolean().describe('是否已处理'),
             actor: z.string().describe('处理人 QQ 号')


### PR DESCRIPTION
* 文档不对。（见编辑记录，视requester_nick为兼容保留的重复，不列出）
* 实测收不到actor。这点由于我用的nc比较旧，不肯定有没有修过，也难以通过读代码确认。
* 看不到是同意还是拒绝。这点从接口中可以看到就没有这个值。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化 `get_group_system_msg` API，简化其请求为空 schema，并通过新增 `message` 字段来增强其响应，用于返回系统消息。

增强功能：
- 从 `get_group_system_msg` 请求 schema 中移除已弃用的 `group_id` 参数
- 在邀请和加入请求的响应中引入 `message` 字段，以包含加入回复文本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the `get_group_system_msg` API by simplifying its request to an empty schema and enhancing its response with a new `message` field for system messages.

Enhancements:
- Remove the deprecated `group_id` parameter from the `get_group_system_msg` request schema
- Introduce a `message` field in both invited and join request responses to include the join reply text

</details>