### PR TITLE
fix: 转发消息接口返回值兼容gocq

### DIFF
--- a/src/onebot/action/msg/SendMsg.ts
+++ b/src/onebot/action/msg/SendMsg.ts
@@ -19,6 +19,7 @@ import { rawMsgWithSendMsg } from '@/core/packet/message/converter';
 export interface ReturnDataType {
     message_id: number;
     res_id?: string;
+    forward_id?: string;
 }
 
 export enum ContextMode {
@@ -147,7 +148,10 @@ export class SendMsgBase extends OneBotAction<OB11PostSendMsg, ReturnDataType> {
                     peerUid: peer.peerUid,
                     chatType: peer.chatType,
                 }, (returnMsgAndResId.message).msgId);
-                return { message_id: msgShortId!, res_id: returnMsgAndResId.res_id! };
+
+                // 对gocq的forward_id进行兼容
+                const resId = returnMsgAndResId.res_id!;
+                return { message_id: msgShortId!, res_id: resId, forward_id: resId };
             } else if (returnMsgAndResId.res_id && !returnMsgAndResId.message) {
                 throw Error(`发送转发消息（res_id：${returnMsgAndResId.res_id} 失败`);
             }


### PR DESCRIPTION
[go-cqhttp docs](https://docs.go-cqhttp.org/api/#%E5%8F%91%E9%80%81%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91-%E7%BE%A4%E8%81%8A)

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加对 go-cqhttp 的兼容性，方法是在 SendMsg 返回数据中包含 `forward_id`，并将其设置为现有的 `res_id`。

Bug 修复：
- 对于 go-cqhttp 转发响应，填充 `forward_id` 等于 `res_id`，以保持兼容性。

增强功能：
- 使用可选的 `forward_id` 字段扩展 `ReturnDataType` 接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add compatibility for go-cqhttp by including a `forward_id` in the SendMsg return data and setting it to the existing `res_id`.

Bug Fixes:
- Populate `forward_id` equal to `res_id` for go-cqhttp forwarding responses to maintain compatibility.

Enhancements:
- Extend the `ReturnDataType` interface with an optional `forward_id` field.

</details>