### PR TITLE
向 /get_system_msg 添加可选参数 'count'

### DIFF
--- a/src/onebot/action/system/GetSystemMsg.ts
+++ b/src/onebot/action/system/GetSystemMsg.ts
@@ -2,6 +2,7 @@ import { GroupNotifyMsgStatus } from '@/core';
 import { OneBotAction } from '@/onebot/action/OneBotAction';
 import { ActionName } from '@/onebot/action/router';
 import { Notify } from '@/onebot/types';
+import { Static, Type } from '@sinclair/typebox';
 
 interface RetData {
     invited_requests: Notify[];
@@ -9,15 +10,18 @@ interface RetData {
     join_requests: Notify[];
 }
 
-export class GetGroupSystemMsg extends OneBotAction<{ count?: number }, RetData> {
-    override actionName = ActionName.GetGroupSystemMsg;
+const SchemaData = Type.Object({
+    count: Type.Union([Type.Number(), Type.String()], { default: 50 }),
+});
 
-    async _handle(params?: { count?: number }): Promise<RetData> {
-        let count = 50;
-        if (params?.count && Number.isInteger(params.count) && params.count > 0) {
-            count = params.count;
-        }
-        const SingleScreenNotifies = await this.core.apis.GroupApi.getSingleScreenNotifies(false, count);
+type Payload = Static<typeof SchemaData>;
+
+export class GetGroupSystemMsg extends OneBotAction<Payload, RetData> {
+    override actionName = ActionName.GetGroupSystemMsg;
+    override payloadSchema = SchemaData;
+
+    async _handle(params: Payload): Promise<RetData> {
+        const SingleScreenNotifies = await this.core.apis.GroupApi.getSingleScreenNotifies(false, +params.count);
         const retData: RetData = { invited_requests: [], InvitedRequest: [], join_requests: [] };
 
         const notifyPromises = SingleScreenNotifies.map(async (SSNotify) => {


### PR DESCRIPTION
#1076

只改了onebot的action代码。没找到调试用的哪里的示例文本

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强功能：
- 向 `GetGroupSystemMsg` 操作添加一个可选的 `count` 参数，以控制检索的消息数量

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add an optional `count` parameter to the `GetGroupSystemMsg` action to control how many messages are retrieved

</details>