### PR TITLE
ci: remove the draft parameter from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
     - name: Clone Changes Log
       run: curl -o CHANGELOG.md https://fastly.jsdelivr.net/gh/NapNeko/NapCatQQ@main/docs/changelogs/CHANGELOG.v${{ env.VERSION }}.md
         
-    - name: Create Release Draft and Upload Artifacts
+    - name: Create Release and Upload Artifacts
       uses: softprops/action-gh-release@v1
       with:
         name: NapCat V${{ env.VERSION }}
@@ -149,7 +149,6 @@ jobs:
           NapCat.Framework.zip
           NapCat.Shell.zip
           NapCat.Framework.Windows.Once.zip
-        draft: true
 
   build-docker:
     needs: release-napcat


### PR DESCRIPTION
After the draft is generated, the subsequent docker build is triggered immediately, but the docker build gets the latest release, resulting in the packaging of the previous version. And because the condition for this CI to be triggered is that the tag contains v*, I personally think that there is no need for manual review, and the release can be created directly.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

立即发布版本，方法是删除 GitHub Actions 发布工作流程中的草稿标志，确保 Docker 构建获取正确的新版本

CI:
- 从 GitHub 发布 action 步骤中删除 `draft` 参数，以创建完全发布的版本
- 将发布步骤从“创建发布草稿并上传工件”重命名为“创建发布并上传工件”

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Publish releases immediately by removing the draft flag in the GitHub Actions release workflow, ensuring the Docker build picks up the correct new version

CI:
- Remove the draft parameter from the GitHub release action step to create a fully published release
- Rename the release step from "Create Release Draft and Upload Artifacts" to "Create Release and Upload Artifacts"

</details>