### PR TITLE
fix: /get_msg interface returns group type message with group_name.

### DIFF
--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -974,6 +974,7 @@ export class OneBotMsgApi {
     private async handleGroupMessage(resMsg: OB11Message, msg: RawMessage) {
         resMsg.sub_type = 'normal';
         resMsg.group_id = parseInt(msg.peerUin);
+        resMsg.group_name = msg.peerName;
         let member = await this.core.apis.GroupApi.getGroupMember(msg.peerUin, msg.senderUin);
         if (!member) member = await this.core.apis.GroupApi.getGroupMember(msg.peerUin, msg.senderUin);
         if (member) {

--- a/src/onebot/types/message.ts
+++ b/src/onebot/types/message.ts
@@ -21,6 +21,7 @@ export interface OB11Message {
     real_id: number;
     user_id: number | string; // number
     group_id?: number | string; // number
+    group_name?: string; // string
     message_type: 'private' | 'group';
     sub_type?: 'friend' | 'group' | 'normal';
     sender: OB11Sender;


### PR DESCRIPTION
方便记日志/显示时，展示群消息来源的群名

## Sourcery 摘要

在群组消息的 OB11 get_msg 响应中包含群组名称，以改进日志记录和显示。

增强：
- 为 OB11Message 类型添加可选的 group_name 属性
- 在 handleGroupMessage 中从 peerName 填充 group_name

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include the group name in the OB11 get_msg response for group messages to improve logging and display.

Enhancements:
- Add optional group_name property to OB11Message type
- Populate group_name from peerName in handleGroupMessage

</details>