### PR TITLE
fix: special char of token in webui url should be url encoded

### DIFF
--- a/src/framework/napcat.ts
+++ b/src/framework/napcat.ts
@@ -15,7 +15,7 @@ import { FFmpegService } from '@/common/ffmpeg';
 //Framework ES入口文件
 export async function getWebUiUrl() {
     const WebUiConfigData = (await WebUiConfig.GetWebUIConfig());
-    return 'http://127.0.0.1:' + webUiRuntimePort + '/webui/?token=' + WebUiConfigData.token;
+    return 'http://127.0.0.1:' + webUiRuntimePort + '/webui/?token=' + encodeURIComponent(WebUiConfigData.token);
 }
 
 export async function NCoreInitFramework(


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 对 WebUI 令牌进行 URL 编码，以便正确处理 Web UI URL 中的特殊字符

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- URL-encode the WebUI token to properly handle special characters in the Web UI URL

</details>