### PR TITLE
修复 每次Napcat启动都会重置用户密码为随机值的BUG

### DIFF
--- a/src/webui/index.ts
+++ b/src/webui/index.ts
@@ -90,7 +90,7 @@ export async function InitWebUi(logger: LogWrapper, pathWrapper: NapCatPathWrapp
     let config = await WebUiConfig.GetWebUIConfig();
 
     // 检查并更新默认密码 - 最高优先级
-    if (config.defaultToken || config.token === 'napcat' || !config.token) {
+    if (config.token === 'napcat' || !config.token) {
         const randomToken = randomBytes(6).toString('hex');
         await WebUiConfig.UpdateWebUIConfig({ token: randomToken, defaultToken: false });
         logger.log(`[NapCat] [WebUi] 🔐 检测到默认密码，已自动更新为安全密码`);


### PR DESCRIPTION
问题发生根源：
src/webui/index.ts 第93行
`if (config.defaultToken || config.token === 'napcat' || !config.token) {`
webui.json中并没有defaultToken字段
随机密码后也没有设置该字段的值
而默认值为True
导致每次启动napcat WebUI密码都被重置为随机

## Sourcery 摘要

错误修复：
- 移除启动逻辑中的 defaultToken 条件，以防止在 defaultToken 不存在时意外地随机重置密码

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove defaultToken condition in startup logic to prevent unintended random password resets when defaultToken isn’t present

</details>