### PR TITLE
找不到类型时显式报错

### DIFF
--- a/src/onebot/api/msg.ts
+++ b/src/onebot/api/msg.ts
@@ -1124,10 +1124,13 @@ export class OneBotMsgApi {
             if (ignoreTypes.includes(sendMsg.type)) {
                 continue;
             }
-            const converter = this.ob11ToRawConverters[sendMsg.type] as (
+            const converter = this.ob11ToRawConverters[sendMsg.type] as ((
                 sendMsg: Extract<OB11MessageData, { type: OB11MessageData['type'] }>,
                 context: SendMessageContext,
-            ) => Promise<SendMessageElement | undefined>;
+            ) => Promise<SendMessageElement | undefined>) | undefined;
+            if (converter == undefined) {
+                throw new Error('未知的消息类型：' + sendMsg.type);
+            }
             const callResult = converter(
                 sendMsg,
                 { peer, deleteAfterSentFiles },


### PR DESCRIPTION
<img width="269" height="168" alt="image" src="https://github.com/user-attachments/assets/87baa8e6-b892-40ac-a326-a81f19b78d5c" />
<img width="422" height="241" alt="image" src="https://github.com/user-attachments/assets/7f4d928e-6cf4-4e24-b201-d75ab9859aae" />
<img width="663" height="293" alt="image" src="https://github.com/user-attachments/assets/16582fa8-7520-4709-94e0-cf25329494ca" />
已经有几个人问过这种问题了，明确告知什么原因会好些。
这么个意思，不保证过编译，但如果过了应该就没问题

```markdown
## Sourcery 总结

Bug 修复：
- 添加对缺失转换器的检查，并针对未知消息类型抛出描述性错误。
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add check for missing converter and throw descriptive error for unknown message types.

</details>