### PR TITLE
fix: get_group_info ownerUin is "0"

### DIFF
--- a/src/onebot/action/group/GetGroupInfo.ts
+++ b/src/onebot/action/group/GetGroupInfo.ts
@@ -18,6 +18,9 @@ class GetGroupInfo extends OneBotAction<Payload, OB11Group> {
         const group = (await this.core.apis.GroupApi.getGroups()).find(e => e.groupCode == payload.group_id.toString());
         if (!group) {
             const data = await this.core.apis.GroupApi.fetchGroupDetail(payload.group_id.toString());
+            if (data.ownerUid && data.ownerUin === '0') {
+                data.ownerUin = await this.core.apis.UserApi.getUinByUidV2(data.ownerUid);
+            }
             return {
                 ...data,
                 group_all_shut: data.shutUpAllTimestamp > 0 ? -1 : 0,


### PR DESCRIPTION
## Sourcery 总结

错误修复：
- 当 `ownerUin` 为 "0" 且 `ownerUid` 可用时，通过调用 `getUinByUidV2` 来填充 `ownerUin`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Populate ownerUin by calling getUinByUidV2 when ownerUin is "0" and ownerUid is available.

</details>