### PR TITLE
Update helper.ts

### DIFF
--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -163,8 +163,8 @@ export function getQQVersionConfigPath(exePath: string = ''): string | undefined
 
 export function calcQQLevel(level?: QQLevel) {
     if (!level) return 0;
-    const { crownNum, sunNum, moonNum, starNum } = level;
-    return crownNum * 64 + sunNum * 16 + moonNum * 4 + starNum;
+    const { penguinNum, crownNum, sunNum, moonNum, starNum } = level;
+    return penguinNum * 256 + crownNum * 64 + sunNum * 16 + moonNum * 4 + starNum;
 }
 
 export function stringifyWithBigInt(obj: any) {


### PR DESCRIPTION
修复256级以后等级清零的问题。

## Sourcery 总结

错误修复:
- 解构 penguinNum 并将其整合到 calcQQLevel 公式中，以防止在达到 256 后等级重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Destructure penguinNum and incorporate it into the calcQQLevel formula to prevent level reset after 256.

</details>