### PR TITLE
fix: 修复了Unix终端打开失败的bug

### DIFF
--- a/src/pty/prebuild-loader.ts
+++ b/src/pty/prebuild-loader.ts
@@ -2,7 +2,7 @@ import { require_dlopen } from '.';
 export function pty_loader () {
   let pty: any;
   try {
-    pty = require_dlopen('./pty/' + process.platform + '.' + process.arch + '/pty.node');
+    pty = require_dlopen('./native/pty/' + process.platform + '.' + process.arch + '/pty.node');
   } catch {
     pty = undefined;
   }


### PR DESCRIPTION
Bug复现：
mlikiowa/napcat-docker:v4.9.23，登陆账号后，在WebUI中打开系统终端失败，查看容器日志报错如下
 Failed to create terminal: TypeError: Cannot read properties of undefined (reading 'fork')
    at new UnixTerminal (file:///app/napcat/napcat.mjs:67721:22)
    at spawn (file:///app/napcat/napcat.mjs:67873:10)
    at TerminalManager.createTerminal (file:///app/napcat/napcat.mjs:67963:17)
    at CreateTerminalHandler (file:///app/napcat/napcat.mjs:68069:36)
    at Layer.handleRequest (/app/napcat/node_modules/router/lib/layer.js:152:17)
    at next (/app/napcat/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/app/napcat/node_modules/router/lib/route.js:117:3)
    at handle (/app/napcat/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/app/napcat/node_modules/router/lib/layer.js:152:17)
    at /app/napcat/node_modules/router/index.js:295:15

定位到源码https://github.com/NapNeko/NapCatQQ/blob/main/src/pty/prebuild-loader.ts#L5
注意到源码中的pty.node路径与容器中实际不符，修改为正确的路径

验证测试：
笔者没有重新构建，而是保持代码逻辑，反过来将pty.node的路径复制到代码中要求的位置，测试发现bug修复

Extra：
注意到native模块中不止有pty模块，还有ffmpeg等其他模块，笔者没有继续看其他模块的加载情况了，如有必要可能需要一并确认load路径

## Sourcery 总结

错误修复:
- 修正 `prebuild-loader` 中 `pty.node` 的加载路径，以解决 Unix 终端创建失败的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the pty.node loading path in prebuild-loader to resolve Unix terminal creation failures

</details>