### PR TITLE
fix(webui-backend): 仅在启用 WebUI 时检测/更新默认密码

### DIFF
--- a/packages/napcat-webui-backend/index.ts
+++ b/packages/napcat-webui-backend/index.ts
@@ -95,7 +95,13 @@ export async function InitWebUi (logger: ILogWrapper, pathWrapper: NapCatPathWra
   WebUiConfig = new WebUiConfigWrapper();
   let config = await WebUiConfig.GetWebUIConfig();
 
-  // 检查并更新默认密码 - 最高优先级
+  // 检查是否禁用WebUI（若禁用则不进行密码检测）
+  if (config.disableWebUI) {
+    logger.log('[NapCat] [WebUi] WebUI is disabled by configuration.');
+    return;
+  }
+
+  // 检查并更新默认密码（仅在启用WebUI时）
   if (config.token === 'napcat' || !config.token) {
     const randomToken = process.env['NAPCAT_WEBUI_SECRET_KEY'] || getRandomToken(8);
     await WebUiConfig.UpdateWebUIConfig({ token: randomToken });
@@ -111,12 +117,6 @@ export async function InitWebUi (logger: ILogWrapper, pathWrapper: NapCatPathWra
 
   // 存储启动时的初始token用于鉴权
   setInitialWebUiToken(config.token);
-
-  // 检查是否禁用WebUI
-  if (config.disableWebUI) {
-    logger.log('[NapCat] [WebUi] WebUI is disabled by configuration.');
-    return;
-  }
 
   const [host, port, token] = await InitPort(config);
   webUiRuntimePort = port;


### PR DESCRIPTION
背景
- 当前在初始化 WebUI 时，即使配置了禁用（disableWebUI=true），仍会检测并更新默认密码 token，导致不必要的配置写入。

变更
- 将对 disableWebUI 的判断提前到 token 检测之前：当禁用时直接返回，不进行 token 检测/更新。
- 仅在 WebUI 启用时才执行默认密码检测与更新，并在最终配置确定后设置 initialWebUiToken。

影响范围
- 仅影响 WebUI 启动流程；当禁用 WebUI 时不再改写配置文件中的 token。
- 启用 WebUI 的行为与预期一致：继续自动更新默认密码（或使用 NAPCAT_WEBUI_SECRET_KEY），并输出相关日志。

风险评估
- 行为变化：当禁用时不会设置内存 token，但服务不会启动，后续逻辑不依赖该值，影响可控。
- 未引入依赖或配置变更。

验证
- Typecheck 通过（pnpm run typecheck）。
- Lint 通过（我们的改动文件无 lint 问题）。

变更文件
- packages/napcat-webui-backend/index.ts

## Sourcery 总结

错误修复：
- 当 `disableWebUI` 为 `true` 时，阻止默认密码令牌检测和配置写入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent default password token detection and config writes when disableWebUI is true

</details>