### PR TITLE
QQ版本架构不支持提示 URL 生成问题

### DIFF
--- a/packages/napcat-core/apis/packet.ts
+++ b/packages/napcat-core/apis/packet.ts
@@ -54,7 +54,7 @@ export class NTQQPacketApi {
     const table = typedOffset[qqVer + '-' + os.arch()];
     if (!table) {
       const err = `[Core] [Packet] PacketBackend 不支持当前QQ版本架构：${qqVer}-${os.arch()}，
-            请参照 https://github.com/NapNeko/NapCatQQ/releases/tag/v${napCatVersion} 配置正确的QQ版本！`;
+            请参照 https://github.com/NapNeko/NapCatQQ/releases/tag/${napCatVersion} 配置正确的QQ版本！`;
       this.logger.logError(err);
       this.errStack.push(err);
       return false;


### PR DESCRIPTION
生成 URL 时出现了重复的 `v`
<img width="1489" height="113" alt="image" src="https://github.com/user-attachments/assets/3ea3b097-c66f-461f-a203-b433166198e0" />

## Summary by Sourcery

Bug Fixes:
- 修复当当前 QQ 版本架构不受支持时，在显示的发布 URL 中出现重复版本前缀的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix duplicated version prefix in the release URL shown when the current QQ version architecture is unsupported.

</details>