### PR TITLE
为 NapCat.Shell - Win 新增后台启动方式

### DIFF
--- a/packages/napcat-shell-loader/launcher-background.bat
+++ b/packages/napcat-shell-loader/launcher-background.bat
@@ -1,0 +1,53 @@
+@echo off
+chcp 65001
+net session >nul 2>&1
+if %errorLevel% == 0 (
+    echo Administrator mode detected.
+) else (
+    echo Please run this script in administrator mode.
+    powershell -Command "Start-Process 'wt.exe' -ArgumentList 'cmd /c cd /d \"%cd%\" && \"%~f0\" %1' -Verb runAs"
+    exit
+)
+
+set NAPCAT_PATCH_PACKAGE=%cd%\qqnt.json
+set NAPCAT_LOAD_PATH=%cd%\loadNapCat.js
+set NAPCAT_INJECT_PATH=%cd%\NapCatWinBootHook.dll
+set NAPCAT_LAUNCHER_PATH=%cd%\NapCatWinBootMain.exe
+set NAPCAT_MAIN_PATH=%cd%\napcat.mjs
+:loop_read
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\QQ" /v "UninstallString"') do (
+    set "RetString=%%~b"
+    goto :napcat_boot
+)
+
+:napcat_boot
+for %%a in ("%RetString%") do (
+    set "pathWithoutUninstall=%%~dpa"
+)
+
+set "QQPath=%pathWithoutUninstall%QQ.exe"
+
+if not exist "%QQPath%" (
+    echo provided QQ path is invalid
+    pause
+    exit /b
+)
+
+set NAPCAT_MAIN_PATH=%NAPCAT_MAIN_PATH:\=/%
+echo (async () =^> {await import("file:///%NAPCAT_MAIN_PATH%")})() > "%NAPCAT_LOAD_PATH%"
+
+@REM 本行以上部分与 launcher.bat 相同，修改以下部分，实现后台启动
+
+@REM 创建 VBS 临时脚本
+set "VBS=%temp%\napcat_start.vbs"
+@REM 后台运行原启动命令
+@REM 首次登录时的二维码和 WebUI token 就去查 log 好了
+echo Set WshShell = CreateObject("WScript.Shell") > "%VBS%"
+echo WshShell.Run """%NAPCAT_LAUNCHER_PATH%"" ""%QQPath%"" ""%NAPCAT_INJECT_PATH%"" %1", 0, False >> "%VBS%"
+
+@REM 执行 VBS 脚本
+cscript //nologo "%VBS%"
+
+@REM 删除临时文件并退出
+del "%VBS%" >nul 2>&1
+exit /b

--- a/packages/napcat-shell-loader/launcher-win10-background.bat
+++ b/packages/napcat-shell-loader/launcher-win10-background.bat
@@ -1,0 +1,46 @@
+@echo off
+chcp 65001
+net session >nul 2>&1
+if %errorLevel% == 0 (
+    echo Administrator mode detected.
+) else (
+    echo Please run this script in administrator mode.
+    powershell -Command "Start-Process 'cmd.exe' -ArgumentList '/c cd /d \"%cd%\" && \"%~f0\" %1' -Verb runAs" 
+    exit
+)
+
+set NAPCAT_PATCH_PACKAGE=%cd%\qqnt.json
+set NAPCAT_LOAD_PATH=%cd%\loadNapCat.js
+set NAPCAT_INJECT_PATH=%cd%\NapCatWinBootHook.dll
+set NAPCAT_LAUNCHER_PATH=%cd%\NapCatWinBootMain.exe
+set NAPCAT_MAIN_PATH=%cd%\napcat.mjs
+:loop_read
+for /f "tokens=2*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\QQ" /v "UninstallString"') do (
+    set "RetString=%%~b"
+    goto :napcat_boot
+)
+
+:napcat_boot
+for %%a in ("%RetString%") do (
+    set "pathWithoutUninstall=%%~dpa"
+)
+
+set "QQPath=%pathWithoutUninstall%QQ.exe"
+
+if not exist "%QQPath%" (
+    echo provided QQ path is invalid
+    pause
+    exit /b
+)
+set NAPCAT_MAIN_PATH=%NAPCAT_MAIN_PATH:\=/%
+echo (async () =^> {await import("file:///%NAPCAT_MAIN_PATH%")})() > "%NAPCAT_LOAD_PATH%"
+
+@REM 参考 launcher-background.bat
+set "VBS=%temp%\napcat_start.vbs"
+echo Set WshShell = CreateObject("WScript.Shell") > "%VBS%"
+echo WshShell.Run """%NAPCAT_LAUNCHER_PATH%"" ""%QQPath%"" ""%NAPCAT_INJECT_PATH%"" %1", 0, False >> "%VBS%"
+
+cscript //nologo "%VBS%"
+
+del "%VBS%" >nul 2>&1
+exit /b


### PR DESCRIPTION
基于原本的 `launcher.bat` 与 `launcher-win10.bat` 实现，修改原脚本中直接执行 `NapCatWinBootMain.exe` 的方式，创建一个临时 vbs 脚本，使用 `CreateObject("WScript.Shell").Run()` 函数执行原命令。
登录需要的二维码和 token 可以去日志里查找。

## Summary by Sourcery

添加新的 Windows 启动脚本，以在无可见控制台窗口的后台模式下启动 NapCat.Shell。

新功能：
- 新增 `launcher-background.bat`，通过临时 VBS 包装器在 Windows 上以后台方式随 QQ 一起启动 NapCat.Shell。
- 新增 `launcher-win10-background.bat`，使用相同的基于 VBS 的方案，提供适用于 Windows 10 的后台启动器变体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new Windows launcher scripts to start NapCat.Shell in background mode without a visible console window.

New Features:
- Introduce launcher-background.bat to launch NapCat.Shell on Windows with QQ in background using a temporary VBS wrapper.
- Introduce launcher-win10-background.bat to provide a Windows 10-compatible background launcher variant using the same VBS-based approach.

</details>