### PR TITLE
feat: Add OB11GroupGrayTipEvent for detecting forged gray tip attacks

### DIFF
--- a/packages/napcat-onebot/event/notice/OB11GroupGrayTipEvent.ts
+++ b/packages/napcat-onebot/event/notice/OB11GroupGrayTipEvent.ts
@@ -1,0 +1,35 @@
+import { OB11BaseNoticeEvent } from './OB11BaseNoticeEvent';
+import { NapCatCore } from 'napcat-core';
+
+/**
+ * 群灰条消息事件
+ * 用于上报未知类型的灰条消息，便于下游检测和处理伪造灰条攻击
+ */
+export class OB11GroupGrayTipEvent extends OB11BaseNoticeEvent {
+  notice_type = 'notify';
+  sub_type = 'gray_tip';
+  group_id: number;
+  user_id: number;        // 真实发送者QQ（如果是伪造的灰条，这就是攻击者）
+  message_id: number;     // 消息ID，可用于撤回
+  busi_id: string;        // 业务ID
+  content: string;        // 灰条内容（JSON字符串）
+  raw_info: unknown;      // 原始信息
+
+  constructor (
+    core: NapCatCore,
+    groupId: number,
+    userId: number,
+    messageId: number,
+    busiId: string,
+    content: string,
+    rawInfo: unknown
+  ) {
+    super(core);
+    this.group_id = groupId;
+    this.user_id = userId;
+    this.message_id = messageId;
+    this.busi_id = busiId;
+    this.content = content;
+    this.raw_info = rawInfo;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `OB11GroupGrayTipEvent` class to report forged gray tip (灰条) messages with `message_id` for recall capability
- Modify `parseOtherJsonEvent` in group.ts to detect and report gray tip attacks
- Key detection logic: Real system gray tips have `senderUin='0'`, forged ones have the attacker's actual QQ number

## Background

Attackers can send forged JSON gray tip messages that appear as system messages (like poke notifications). These messages have `senderUin` set to the attacker's QQ number instead of `'0'`. This PR enables downstream bots to:

1. Detect forged gray tips by checking `user_id !== 0`
2. Identify the attacker via `user_id` field
3. Recall the forged message using `message_id`
4. Take action (mute, kick, notify admin)

## Event Format

```json
{
  "post_type": "notice",
  "notice_type": "notify",
  "sub_type": "gray_tip",
  "group_id": 123456789,
  "user_id": 987654321,
  "message_id": 12345,
  "busi_id": "2050",
  "content": "{...json content...}",
  "raw_info": {...}
}
```

## Test Plan

- [ ] Test with normal gray tip messages (should not trigger event)
- [ ] Test with forged gray tip messages (should trigger event with correct attacker QQ)
- [ ] Verify message_id can be used for recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

添加对未知群灰条消息的上报，将其作为新的 OneBot 通知事件，以帮助检测并处理伪造的灰条攻击。

新功能：
- 引入 `OB11GroupGrayTipEvent` 通知用于群灰条消息，对下游机器人暴露群号、攻击者用户 ID、消息 ID、业务 ID、内容以及原始信息等字段。

增强：
- 扩展群 JSON 灰条解析逻辑，传递完整的灰条元素元数据，并在检测到由非系统发送方发出的未知灰条时触发灰条事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add reporting for unknown group gray tip messages as a new OneBot notice event to help detect and handle forged gray tip attacks.

New Features:
- Introduce OB11GroupGrayTipEvent notice for group gray tip messages, exposing group, attacker user ID, message ID, business ID, content, and raw info to downstream bots.

Enhancements:
- Extend group JSON gray tip parsing to pass full gray tip element metadata and emit gray tip events when unknown gray tips with non-system senders are detected.

</details>