### PR TITLE
feat: Add OB11GroupGrayTipEvent for detecting forged gray tip attacks

### DIFF
--- a/packages/napcat-onebot/api/group.ts
+++ b/packages/napcat-onebot/api/group.ts
@@ -23,6 +23,7 @@ import { OB11GroupUploadNoticeEvent } from '../event/notice/OB11GroupUploadNotic
 import { OB11GroupNameEvent } from '../event/notice/OB11GroupNameEvent';
 import { FileNapCatOneBotUUID } from 'napcat-common/src/file-uuid';
 import { OB11GroupIncreaseEvent } from '../event/notice/OB11GroupIncreaseEvent';
+import { OB11GroupGrayTipEvent } from '../event/notice/OB11GroupGrayTipEvent';
 import { NapProtoMsg } from 'napcat-protobuf';
 import { GroupReactNotify, PushMsg } from 'napcat-core/packet/transformer/proto';
 import { NapCatOneBot11Adapter } from '..';
@@ -207,24 +208,57 @@ export class OneBotGroupApi {
     return undefined;
   }
 
-  async parseOtherJsonEvent (msg: RawMessage, jsonStr: string, context: InstanceContext) {
-    const json = JSON.parse(jsonStr);
-    const type = json.items[json.items.length - 1]?.txt;
+  async parseOtherJsonEvent (msg: RawMessage, jsonGrayTipElement: GrayTipElement['jsonGrayTipElement'], context: InstanceContext) {
+    let json: { items?: { txt?: string; param?: string[] }[] };
+    try {
+      json = JSON.parse(jsonGrayTipElement.jsonStr);
+    } catch (e) {
+      context.logger.logWarn('灰条消息JSON解析失败', jsonGrayTipElement.jsonStr, e);
+      return undefined;
+    }
+    const type = json.items?.[json.items.length - 1]?.txt;
     await this.core.apis.GroupApi.refreshGroupMemberCachePartial(msg.peerUid, msg.senderUid);
     if (type === '头衔') {
-      const memberUin = json.items[1].param[0];
-      const title = json.items[3].txt;
+      const memberUin = json.items?.[1]?.param?.[0];
+      const title = json.items?.[3]?.txt;
       context.logger.logDebug('收到群成员新头衔消息', json);
       return new OB11GroupTitleEvent(
         this.core,
         +msg.peerUid,
-        +memberUin,
-        title
+        +(memberUin ?? 0),
+        title ?? ''
       );
     } else if (type === '移出') {
       context.logger.logDebug('收到机器人被踢消息', json);
     } else {
-      context.logger.logWarn('收到未知的灰条消息', json);
+      // 未知灰条消息 - 生成事件上报，便于检测伪造灰条攻击
+      const senderUin = Number(msg.senderUin) || 0;
+      context.logger.logWarn('收到未知的灰条消息', {
+        busiId: jsonGrayTipElement.busiId,
+        senderUin,
+        peerUin: msg.peerUin,
+        json,
+      });
+
+      // 如果有真实发送者（非0），生成事件上报，可用于检测和撤回伪造灰条
+      if (senderUin !== 0) {
+        const peer = { chatType: ChatType.KCHATTYPEGROUP, guildId: '', peerUid: msg.peerUid };
+        const messageId = MessageUnique.createUniqueMsgId(peer, msg.msgId);
+        return new OB11GroupGrayTipEvent(
+          this.core,
+          +msg.peerUin,
+          senderUin,
+          messageId,
+          jsonGrayTipElement.busiId,
+          jsonGrayTipElement.jsonStr,
+          {
+            msgSeq: msg.msgSeq,
+            msgTime: msg.msgTime,
+            msgId: msg.msgId,
+            json,
+          }
+        );
+      }
     }
     return undefined;
   }
@@ -375,8 +409,7 @@ export class OneBotGroupApi {
         // 51是什么？{"align":"center","items":[{"txt":"下一秒起床通过王者荣耀加入群","type":"nor"}]
         return await this.parse51TypeEvent(msg, grayTipElement);
       } else {
-        console.log('Unknown JSON event:', grayTipElement.jsonGrayTipElement, JSON.stringify(grayTipElement));
-        return await this.parseOtherJsonEvent(msg, grayTipElement.jsonGrayTipElement.jsonStr, this.core.context);
+        return await this.parseOtherJsonEvent(msg, grayTipElement.jsonGrayTipElement, this.core.context);
       }
     }
     return undefined;

--- a/packages/napcat-onebot/event/notice/OB11GroupGrayTipEvent.ts
+++ b/packages/napcat-onebot/event/notice/OB11GroupGrayTipEvent.ts
@@ -1,0 +1,35 @@
+import { OB11BaseNoticeEvent } from './OB11BaseNoticeEvent';
+import { NapCatCore } from 'napcat-core';
+
+/**
+ * 群灰条消息事件
+ * 用于上报未知类型的灰条消息，便于下游检测和处理伪造灰条攻击
+ */
+export class OB11GroupGrayTipEvent extends OB11BaseNoticeEvent {
+  notice_type = 'notify';
+  sub_type = 'gray_tip';
+  group_id: number;
+  user_id: number;        // 真实发送者QQ（如果是伪造的灰条，这就是攻击者）
+  message_id: number;     // 消息ID，可用于撤回
+  busi_id: string;        // 业务ID
+  content: string;        // 灰条内容（JSON字符串）
+  raw_info: unknown;      // 原始信息
+
+  constructor (
+    core: NapCatCore,
+    groupId: number,
+    userId: number,
+    messageId: number,
+    busiId: string,
+    content: string,
+    rawInfo: unknown
+  ) {
+    super(core);
+    this.group_id = groupId;
+    this.user_id = userId;
+    this.message_id = messageId;
+    this.busi_id = busiId;
+    this.content = content;
+    this.raw_info = rawInfo;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `OB11GroupGrayTipEvent` class to report forged gray tip (灰条) messages with `message_id` for recall capability
- Modify `parseOtherJsonEvent` in group.ts to detect and report gray tip attacks
- Key detection logic: Real system gray tips have `senderUin='0'`, forged ones have the attacker's actual QQ number

## Background

Attackers can send forged JSON gray tip messages that appear as system messages (like poke notifications). These messages have `senderUin` set to the attacker's QQ number instead of `'0'`. This PR enables downstream bots to:

1. Detect forged gray tips by checking `user_id !== 0`
2. Identify the attacker via `user_id` field
3. Recall the forged message using `message_id`
4. Take action (mute, kick, notify admin)

## Event Format

```json
{
  "post_type": "notice",
  "notice_type": "notify",
  "sub_type": "gray_tip",
  "group_id": 123456789,
  "user_id": 987654321,
  "message_id": 12345,
  "busi_id": "2050",
  "content": "{...json content...}",
  "raw_info": {...}
}
```

## Test Plan

- [ ] Test with normal gray tip messages (should not trigger event)
- [ ] Test with forged gray tip messages (should trigger event with correct attacker QQ)
- [ ] Verify message_id can be used for recall

## 由 Sourcery 提供的摘要

将未知的群灰度提示消息报告为 notice 事件，用于检测群聊中的伪造系统消息。

新功能：
- 引入 `OB11GroupGrayTipEvent` notice，用于灰度提示消息，包括群信息、发送者、消息内容和业务元数据。

增强内容：
- 扩展群灰度提示的 JSON 解析，以传递完整的灰度提示元素数据，并发出结构化事件，而不是仅仅记录未知消息日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Report unknown group gray-tip messages as notice events for detecting forged system messages in group chats.

New Features:
- Introduce OB11GroupGrayTipEvent notice for gray-tip messages including group, sender, message, and business metadata.

Enhancements:
- Extend group gray-tip JSON parsing to pass full gray-tip element data and emit structured events instead of only logging unknown messages.

</details>