### PR TITLE
Rename OB11MessageContext to OB11MessageContact

### DIFF
--- a/packages/napcat-onebot/types/message.ts
+++ b/packages/napcat-onebot/types/message.ts
@@ -103,7 +103,7 @@ export interface OB11MessageText {
 }
 
 // 联系人消息接口定义
-export interface OB11MessageContext {
+export interface OB11MessageContact {
   type: OB11MessageDataType.contact;
   data: {
     type: 'qq' | 'group';
@@ -260,7 +260,7 @@ export type OB11MessageData =
   OB11MessageAt | OB11MessageReply |
   OB11MessageImage | OB11MessageRecord | OB11MessageFile | OB11MessageVideo |
   OB11MessageNode | OB11MessageIdMusic | OB11MessageCustomMusic | OB11MessageJson |
-  OB11MessageDice | OB11MessageRPS | OB11MessageMarkdown | OB11MessageForward | OB11MessageContext | OB11MessagePoke;
+  OB11MessageDice | OB11MessageRPS | OB11MessageMarkdown | OB11MessageForward | OB11MessageContact | OB11MessagePoke;
 
 // 发送消息接口定义
 export interface OB11PostSendMsg {


### PR DESCRIPTION
This pull request updates the OneBot message type definitions to clarify the naming of the contact message interface. The main change is a rename of the interface to improve clarity and consistency.

Type definition improvements:

* Renamed the contact message interface from `OB11MessageContext` to `OB11MessageContact` in `message.ts` to better reflect its purpose.
* Updated the `OB11MessageData` union type to use the new `OB11MessageContact` name instead of the old `OB11MessageContext`.