### PR TITLE
修复下载插件后插件列表显示开启

### DIFF
--- a/packages/napcat-webui-frontend/src/components/display_card/plugin_card.tsx
+++ b/packages/napcat-webui-frontend/src/components/display_card/plugin_card.tsx
@@ -24,7 +24,7 @@ const PluginDisplayCard: React.FC<PluginDisplayCardProps> = ({
   hasConfig = false,
 }) => {
   const { name, version, author, description, status } = data;
-  const isEnabled = status !== 'disabled';
+  const isEnabled = status === 'active';
   const [processing, setProcessing] = useState(false);
 
   const handleToggle = () => {


### PR DESCRIPTION
下载后插件应该为禁用状态，但是前端显示启用状态