### PR TITLE
修改合并消息上传资源日志

### DIFF
--- a/packages/napcat-core/packet/context/operationContext.ts
+++ b/packages/napcat-core/packet/context/operationContext.ts
@@ -95,12 +95,15 @@ export class PacketOperationContext {
         .filter(Boolean)
     );
     const res = await Promise.allSettled(reqList);
-    this.context.logger.info(`上传资源${res.length}个，失败${res.filter((r) => r.status === 'rejected').length}个`);
-    res.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        this.context.logger.error(`上传第${index + 1}个资源失败：${result.reason.stack}`);
-      }
-    });
+    const failedCount = res.filter((r) => r.status === 'rejected').length;
+    if (failedCount > 0) {
+      this.context.logger.warn(`上传资源${res.length}个，失败${failedCount}个`);
+      res.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          this.context.logger.error(`上传第${index + 1}个资源失败：${result.reason.stack}`);
+        }
+      });
+    }
   }
 
   async UploadImage (img: PacketMsgPicElement) {


### PR DESCRIPTION
当上传资源有失败时为warn+error详细日志
全部成功则不输出日志
<img width="803" height="316" alt="56095fade9fbacecf0fb56fa47f42333" src="https://github.com/user-attachments/assets/144871d9-45bc-4031-a652-c6b17c76e64e" />
