### PR TITLE
​refactor(msg): 分离 ID 音乐与自定义音乐 (custom_music) 处理逻辑并增强类型校验

### DIFF
--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -8,7 +8,6 @@ import {
   FaceType,
   GrayTipElement,
   GroupNotify,
-  IdMusicSignPostData,
   MessageElement,
   NapCatCore,
   NTGrayTipElementSubTypeV2,
@@ -85,6 +84,10 @@ export type RecvMessageContext = {
 function keyCanBeParsed (key: string, parser: RawToOb11Converters): key is keyof RawToOb11Converters {
   return key in parser;
 }
+
+// Music platform constants
+const SUPPORTED_MUSIC_PLATFORMS = ['qq', '163', 'kugou', 'kuwo', 'migu'] as const;
+const CUSTOM_MUSIC_TYPE = 'custom';
 
 export class OneBotMsgApi {
   obContext: NapCatOneBot11Adapter;
@@ -798,34 +801,61 @@ export class OneBotMsgApi {
     }),
 
     [OB11MessageDataType.music]: async ({ data }, context) => {
-      // 保留, 直到...找到更好的解决方案
-      const supportedPlatforms = ['qq', '163', 'kugou', 'kuwo', 'migu'];
-      const supportedPlatformsWithCustom = [...supportedPlatforms, 'custom'];
+      // ID音乐消息段处理
+      // 验证音乐类型
+      if (!(SUPPORTED_MUSIC_PLATFORMS as readonly string[]).includes(data.type)) {
+        this.core.context.logger.logError(`[音乐卡片] type参数错误: "${data.type}"，仅支持: ${SUPPORTED_MUSIC_PLATFORMS.join('、')}`);
+        return undefined;
+      }
+
+      // 获取签名服务地址
+      let signUrl = this.obContext.configLoader.configData.musicSignUrl;
+      if (!signUrl) {
+        signUrl = 'https://ss.xingzhige.com/music_card/card'; // 感谢思思！已获思思许可 其余地方使用请自行询问
+      }
+
+      // 请求签名服务
+      try {
+        const musicJson = await RequestUtil.HttpGetJson<string>(signUrl, 'POST', data);
+        return this.ob11ToRawConverters.json({
+          data: { data: musicJson },
+          type: OB11MessageDataType.json,
+        }, context);
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        this.core.context.logger.logError(
+          '[音乐卡片签名失败] 签名服务请求出错!\n' +
+          `  ├─ 音乐类型: ${data.type}\n` +
+          `  ├─ 音乐ID: ${data.id}\n` +
+          `  ├─ 错误信息: ${errorMessage}\n` +
+          '  └─ 提示: 请检查网络连接，或尝试在配置中更换其他音乐签名服务地址(musicSignUrl)'
+        );
+        return undefined;
+      }
+    },
+
+    [OB11MessageDataType.custom_music]: async ({ data }, context) => {
+      // 自定义音乐消息段处理
+      const supportedPlatformsWithCustom = [...SUPPORTED_MUSIC_PLATFORMS, CUSTOM_MUSIC_TYPE];
 
       // 验证音乐类型
-      if (data.id !== undefined) {
-        if (!supportedPlatforms.includes(data.type)) {
-          this.core.context.logger.logError(`[音乐卡片] type参数错误: "${data.type}"，仅支持: ${supportedPlatforms.join('、')}`);
-          return undefined;
-        }
-      } else {
-        if (!supportedPlatformsWithCustom.includes(data.type)) {
-          this.core.context.logger.logError(`[音乐卡片] type参数错误: "${data.type}"，仅支持: ${supportedPlatformsWithCustom.join('、')}`);
-          return undefined;
-        }
-        if (!data.url) {
-          this.core.context.logger.logError('[音乐卡片] 自定义音乐卡片缺少必需参数: url');
-          return undefined;
-        }
-        if (!data.image) {
-          this.core.context.logger.logError('[音乐卡片] 自定义音乐卡片缺少必需参数: image');
-          return undefined;
-        }
+      if (!supportedPlatformsWithCustom.includes(data.type)) {
+        this.core.context.logger.logError(`[音乐卡片] type参数错误: "${data.type}"，仅支持: ${supportedPlatformsWithCustom.join('、')}`);
+        return undefined;
+      }
+      if (!data.url) {
+        this.core.context.logger.logError('[音乐卡片] 自定义音乐卡片缺少必需参数: url');
+        return undefined;
+      }
+      if (!data.image) {
+        this.core.context.logger.logError('[音乐卡片] 自定义音乐卡片缺少必需参数: image');
+        return undefined;
       }
 
       // 构建请求数据
-      let postData: IdMusicSignPostData | CustomMusicSignPostData;
-      if (data.id === undefined && data.content) {
+      // 注意: 自定义音乐消息段不包含 id 字段，只处理 content 到 singer 的映射
+      let postData: CustomMusicSignPostData;
+      if (data.content) {
         const { content, ...others } = data;
         postData = { singer: content, ...others };
       } else {
@@ -835,7 +865,7 @@ export class OneBotMsgApi {
       // 获取签名服务地址
       let signUrl = this.obContext.configLoader.configData.musicSignUrl;
       if (!signUrl) {
-        signUrl = 'https://ss.xingzhige.com/music_card/card';// 感谢思思！已获思思许可 其余地方使用请自行询问
+        signUrl = 'https://ss.xingzhige.com/music_card/card'; // 感谢思思！已获思思许可 其余地方使用请自行询问
       }
 
       // 请求签名服务
@@ -850,7 +880,7 @@ export class OneBotMsgApi {
         this.core.context.logger.logError(
           '[音乐卡片签名失败] 签名服务请求出错!\n' +
           `  ├─ 音乐类型: ${data.type}\n` +
-          `  ├─ 音乐ID: ${data.id ?? '自定义'}\n` +
+          '  ├─ 音乐ID: 自定义\n' +
           `  ├─ 错误信息: ${errorMessage}\n` +
           '  └─ 提示: 请检查网络连接，或尝试在配置中更换其他音乐签名服务地址(musicSignUrl)'
         );

--- a/packages/napcat-onebot/types/message.ts
+++ b/packages/napcat-onebot/types/message.ts
@@ -4,6 +4,7 @@ export enum OB11MessageDataType {
   text = 'text',
   image = 'image',
   music = 'music',
+  custom_music = 'custom_music',
   video = 'video',
   voice = 'record',
   file = 'file',
@@ -160,7 +161,7 @@ export const OB11MessageIdMusicSchema = Type.Object({
 
 // 自定义音乐消息段
 export const OB11MessageCustomMusicSchema = Type.Object({
-  type: Type.Literal(OB11MessageDataType.music),
+  type: Type.Literal(OB11MessageDataType.custom_music),
   data: CustomMusicDataSchema,
 }, { $id: 'OB11MessageCustomMusic', description: '自定义音乐消息段' });
 


### PR DESCRIPTION
📝 变更描述 (Description)
本 PR 对 OneBot 消息处理接口中的音乐卡片逻辑进行了重构。主要将原本混合或处理不清的 music（ID 点歌）与 custom_music（自定义音乐分享）拆分为两个独立的处理器，并优化了代码结构和错误提示。
✨ 具体改动 (Changes)
 * 类型定义更新 (types/message.ts):
   * 在 OB11MessageDataType 枚举中新增 custom_music 类型。
   * 更新 OB11MessageCustomMusicSchema，使其 type 字段正确指向 custom_music。
 * 逻辑分离与重构 (api/msg.ts):
   * 提取了 SUPPORTED_MUSIC_PLATFORMS 和 CUSTOM_MUSIC_TYPE 常量，减少硬编码。
   * ID 音乐处理 (music): 专注于处理基于平台 ID 的点歌请求，增加了对 type 参数的严格白名单校验（仅支持 qq, 163, kugou, kuwo, migu）。
   * 自定义音乐处理 (custom_music): 新增独立的处理器，专门处理自定义卡片。
     * 增加了必要的参数校验：确保 url 和 image 字段存在，不存在时会输出明确的错误日志。
     * 修正了 Post 数据构建逻辑，移除了 ID 字段，并正确处理 content 字段的映射。
 * 错误处理优化:
   * 优化了音乐卡片签名失败时的日志输出，现在能更清晰地显示具体的错误信息、音乐类型和 ID（或“自定义”标识）。
🔗 关联 Issue (Related Issue)
Closes #1602

✅ 测试计划 (Test Plan)
 * [ ] 发送普通 ID 点歌消息（如 QQ 音乐、网易云），确认能正确获取签名并发送。
 * [ ] 发送自定义音乐卡片消息，确认在缺少 url 或 image 时会报错拦截。
 * [ ] 发送完整的自定义音乐卡片，确认能正确生成 JSON 并发送。
