### PR TITLE
Refine NodeIKernel service interfaces

### DIFF
--- a/packages/napcat-core/services/NodeIKernelAVSDKService.ts
+++ b/packages/napcat-core/services/NodeIKernelAVSDKService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelAVSDKService {
+  addKernelAVSDKListener (listener: unknown): number;
+
+  removeKernelAVSDKListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelAddBuddyService.ts
+++ b/packages/napcat-core/services/NodeIKernelAddBuddyService.ts
@@ -1,0 +1,15 @@
+export interface NodeIKernelAddBuddyService {
+  addBuddy (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  getAddBuddyRequestTag (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  getBuddySetting (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  getSmartInfo (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  queryUinSafetyFlag (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  requestInfoByAccount (arg1: string, arg2: unknown, arg3: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelAlbumService.ts
+++ b/packages/napcat-core/services/NodeIKernelAlbumService.ts
@@ -2,17 +2,17 @@ import { AlbumCommentReplyContent, AlbumFeedLikePublish, AlbumListRequest, Album
 
 export interface NodeIKernelAlbumService {
 
-  setAlbumServiceInfo(...args: unknown[]): unknown;// needs 3 arguments
+  setAlbumServiceInfo (arg1: string, arg2: string, arg3: string): unknown;// needs 3 arguments
 
-  getMainPage(...args: unknown[]): unknown;// needs 2 arguments
+  getMainPage (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 
-  getAlbumList(params: {
+  getAlbumList (params: {
     qun_id: string,
     attach_info: string,
     seq: number,
     request_time_line: {
-      request_invoke_time: string
-    }
+      request_invoke_time: string;
+    };
   }): Promise<{
     response: {
       seq: number,
@@ -21,57 +21,57 @@ export interface NodeIKernelAlbumService {
       trace_id: string,
       is_from_cache: boolean,
       request_time_line: unknown,
-      album_list: Array<{ name: string, album_id: string }>,
+      album_list: Array<{ name: string, album_id: string; }>,
       attach_info: string,
       has_more: boolean,
       right: unknown,
-      banner: unknown
-    }
-  }>
-  getAlbumInfo(...args: unknown[]): unknown;// needs 1 arguments
+      banner: unknown;
+    };
+  }>;
+  getAlbumInfo (arg: unknown): unknown;// needs 1 arguments
 
-  deleteAlbum(...args: unknown[]): unknown;// needs 3 arguments
+  deleteAlbum (arg1: number, arg2: string, arg3: string): unknown;// needs 3 arguments
 
-  addAlbum(...args: unknown[]): unknown;// needs 2 arguments
+  addAlbum (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 
-  deleteMedias(seq: number, group_code: string, album_id: string, media_ids: string[], ban_ids: unknown[]): Promise<unknown>;// needs 4 arguments
+  deleteMedias (seq: number, group_code: string, album_id: string, media_ids: string[], ban_ids: unknown[]): Promise<unknown>;// needs 4 arguments
 
-  modifyAlbum(...args: unknown[]): unknown;// needs 3 arguments
+  modifyAlbum (arg1: number, arg2: unknown, arg3: Array<unknown>[]): unknown;// needs 3 arguments
 
-  getMediaList(param: AlbumListRequest): Promise<{
+  getMediaList (param: AlbumListRequest): Promise<{
     response: {
       seq: number,
       result: number,
       errMs: string, // 没错就是errMs不是errMsg
       trace_id: string,
       request_time_line: unknown,
-    }
+    };
   }>;// needs 1 arguments
 
-  quoteToQzone(...args: unknown[]): unknown;// needs 1 arguments
+  quoteToQzone (arg: unknown): unknown;// needs 1 arguments
 
-  quoteToQunAlbum(...args: unknown[]): unknown;// needs 1 arguments
+  quoteToQunAlbum (arg: unknown): unknown;// needs 1 arguments
 
-  queryQuoteToQunAlbumStatus(...args: unknown[]): unknown;// needs 1 arguments
+  queryQuoteToQunAlbumStatus (arg: unknown): unknown;// needs 1 arguments
 
-  getQunFeeds(...args: unknown[]): unknown;// needs 1 arguments
+  getQunFeeds (arg: unknown): unknown;// needs 1 arguments
 
-  getQunFeedDetail(...args: unknown[]): unknown;// needs 1 arguments
+  getQunFeedDetail (arg: unknown): unknown;// needs 1 arguments
 
-  getQunNoticeList(...args: unknown[]): unknown;// needs 4 arguments
+  getQunNoticeList (arg1: number, arg2: unknown, arg3: string, arg4: string): unknown;// needs 4 arguments
 
-  getQunComment(...args: unknown[]): unknown;// needs 1 arguments
+  getQunComment (arg: unknown): unknown;// needs 1 arguments
 
-  getQunLikes(...args: unknown[]): unknown;// needs 4 arguments
+  getQunLikes (arg1: number, arg2: unknown, arg3: string, arg4: string): unknown;// needs 4 arguments
 
-  deleteQunFeed(...args: unknown[]): unknown;// needs 1 arguments
+  deleteQunFeed (arg: unknown): unknown;// needs 1 arguments
   // seq random
   // stCommonExt {"map_info":[],"map_bytes_info":[],"map_user_account":[]}
   // qunId string
-  doQunComment(seq: number, ext: {
+  doQunComment (seq: number, ext: {
     map_info: unknown[],
     map_bytes_info: unknown[],
-    map_user_account: unknown[]
+    map_user_account: unknown[];
   },
     qunId: string,
     commentType: number,
@@ -79,23 +79,23 @@ export interface NodeIKernelAlbumService {
     content: AlbumCommentReplyContent,
   ): Promise<unknown>;// needs 6 arguments
 
-  doQunReply(...args: unknown[]): unknown;// needs 7 arguments
+  doQunReply (arg1: number, arg2: unknown, arg3: string, arg4: number, arg5: unknown, arg6: unknown, arg7: unknown): unknown;// needs 7 arguments
 
-  doQunLike(
+  doQunLike (
     seq: number,
     ext: {
       map_info: unknown[],
       map_bytes_info: unknown[],
-      map_user_account: unknown[]
+      map_user_account: unknown[];
     },
     param: {
       // {"id":"421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|V5bCgAxMDEyOTU5MjU3e*KqaLVYdic!^||^421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|17560336594^||^1","status":1}
       id: string,
-      status: number
+      status: number;
     },
     like: AlbumFeedLikePublish
   ): Promise<unknown>;// needs 5 arguments
 
-  getRedPoints(...args: unknown[]): unknown;// needs 3 arguments
+  getRedPoints (arg1: string, arg2: number, arg3: string): unknown;// needs 3 arguments
 
 }

--- a/packages/napcat-core/services/NodeIKernelAvatarService.ts
+++ b/packages/napcat-core/services/NodeIKernelAvatarService.ts
@@ -13,13 +13,13 @@ export interface NodeIKernelAvatarService {
 
   forceDownloadGroupAvatar(arg1: unknown, arg2: unknown): unknown;
 
-  getGroupPortraitPath(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  getGroupPortraitPath(arg1: string, arg2: number, arg3: number): unknown;
 
-  forceDownloadGroupPortrait(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  forceDownloadGroupPortrait(arg1: string, arg2: number, arg3: number): unknown;
 
-  getAvatarPaths(arg1: unknown, arg2: unknown): unknown;
+  getAvatarPaths(arg1: Array<unknown>[], arg2: number): unknown;
 
-  getGroupAvatarPaths(arg1: unknown, arg2: unknown): unknown;
+  getGroupAvatarPaths(arg1: Array<unknown>[], arg2: string): unknown;
 
   getConfGroupAvatarPaths(arg: unknown): unknown;
 

--- a/packages/napcat-core/services/NodeIKernelBdhUploadService.ts
+++ b/packages/napcat-core/services/NodeIKernelBdhUploadService.ts
@@ -1,0 +1,9 @@
+export interface NodeIKernelBdhUploadService {
+  addKernelBdhUploadListener (listener: unknown): number;
+
+  removeKernelBdhUploadListener (listenerId: number): void;
+
+  setBdhTestEnv (arg1: string, arg2: number): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelBuddyService.ts
+++ b/packages/napcat-core/services/NodeIKernelBuddyService.ts
@@ -130,5 +130,21 @@ export interface NodeIKernelBuddyService {
 
   getBuddyRecommendContactArkJson (uid: string, phoneNumber: string): Promise<GeneralCallResult & { arkMsg: string; }>;
 
+  checkIsBuddyAsync (uid: string): Promise<unknown>;
+
+  areBuddies (callFrom: string, uids: string[]): unknown;
+
+  getCategoryById (id: number): unknown;
+
+  addCategoryV2 (name: string, buddyUids?: unknown): Promise<unknown>;
+
   isNull (): boolean;
+
+  getAddFriendBlockedList (): unknown;
+
+  getAddFriendBlockedRedPoint (): unknown;
+
+  reportAddFriendBlocked (): unknown;
+
+  setWXMsgNotify (arg: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelCollectionService.ts
+++ b/packages/napcat-core/services/NodeIKernelCollectionService.ts
@@ -1,91 +1,91 @@
 import { GeneralCallResult } from './common';
 
 export interface NodeIKernelCollectionService {
-  addKernelCollectionListener(...args: unknown[]): void;// needs 1 arguments
+  addKernelCollectionListener (listener: unknown): void;// needs 1 arguments
 
-  removeKernelCollectionListener(listenerId: number): void;
+  removeKernelCollectionListener (listenerId: number): void;
 
-  getCollectionItemList(param: {
+  getCollectionItemList (param: {
     category: number,
     groupId: number,
     forceSync: boolean,
     forceFromDb: boolean,
     timeStamp: string,
     count: number,
-    searchDown: boolean
+    searchDown: boolean;
   }): Promise<GeneralCallResult &
-    {
-      collectionSearchList: {
-        collectionItemList: Array<
-                {
-                  cid: string,
-                  type: number,
-                  status: number,
-                  author: {
-                    type: number,
-                    numId: string,
-                    strId: string,
-                    groupId: string,
-                    groupName: string,
-                    uid: string
-                  },
-                  bid: number,
-                  category: number,
-                  createTime: string,
-                  collectTime: string,
-                  modifyTime: string,
-                  sequence: string,
-                  shareUrl: string,
-                  customGroupId: number,
-                  securityBeat: boolean,
-                  summary: {
-                    textSummary: unknown,
-                    linkSummary: unknown,
-                    gallerySummary: unknown,
-                    audioSummary: unknown,
-                    videoSummary: unknown,
-                    fileSummary: unknown,
-                    locationSummary: unknown,
-                    richMediaSummary: unknown,
-                  }
-                }>,
-        hasMore: boolean,
-        bottomTimeStamp: string
-      }
-    }
-    >;
+  {
+    collectionSearchList: {
+      collectionItemList: Array<
+        {
+          cid: string,
+          type: number,
+          status: number,
+          author: {
+            type: number,
+            numId: string,
+            strId: string,
+            groupId: string,
+            groupName: string,
+            uid: string;
+          },
+          bid: number,
+          category: number,
+          createTime: string,
+          collectTime: string,
+          modifyTime: string,
+          sequence: string,
+          shareUrl: string,
+          customGroupId: number,
+          securityBeat: boolean,
+          summary: {
+            textSummary: unknown,
+            linkSummary: unknown,
+            gallerySummary: unknown,
+            audioSummary: unknown,
+            videoSummary: unknown,
+            fileSummary: unknown,
+            locationSummary: unknown,
+            richMediaSummary: unknown,
+          };
+        }>,
+      hasMore: boolean,
+      bottomTimeStamp: string;
+    };
+  }
+  >;
 
-  getCollectionContent(...args: unknown[]): unknown;// needs 5 arguments
+  getCollectionContent (arg1: string, arg2: number, arg3: string, arg4: string, arg5: boolean): unknown;// needs 5 arguments
 
-  getCollectionCustomGroupList(...args: unknown[]): unknown;// needs 0 arguments
+  getCollectionCustomGroupList (): unknown;// needs 0 arguments
 
-  getCollectionUserInfo(...args: unknown[]): unknown;// needs 0 arguments
+  getCollectionUserInfo (): unknown;// needs 0 arguments
 
-  searchCollectionItemList(...args: unknown[]): unknown;// needs 2 arguments
+  searchCollectionItemList (arg1: string, arg2: unknown): unknown;// needs 2 arguments
 
-  addMsgToCollection(...args: unknown[]): unknown;// needs 2 arguments
+  addMsgToCollection (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 
-  collectionArkShare(...args: unknown[]): unknown;// needs 1 arguments
+  collectionArkShare (arg: unknown): unknown;// needs 1 arguments
 
-  collectionFileForward(...args: unknown[]): unknown;// needs 3 arguments
+  collectionFileForward (arg1: number, arg2: string, arg3: unknown): unknown;// needs 3 arguments
 
-  downloadCollectionFile(...args: unknown[]): unknown;// needs 4 arguments
+  downloadCollectionFile (arg1: string, arg2: string, arg3: unknown, arg4: string): unknown;// needs 4 arguments
 
-  downloadCollectionFileThumbPic(...args: unknown[]): unknown;// needs 4 arguments
+  downloadCollectionFileThumbPic (arg1: string, arg2: string, arg3: unknown, arg4: number): unknown;// needs 4 arguments
 
-  downloadCollectionPic(...args: unknown[]): unknown;// needs 3 arguments
+  downloadCollectionPic (arg1: string, arg2: string, arg3: unknown): unknown;// needs 3 arguments
 
-  cancelDownloadCollectionFile(...args: unknown[]): unknown;// needs 1 arguments
+  cancelDownloadCollectionFile (arg: unknown): unknown;// needs 1 arguments
 
-  deleteCollectionItemList(...args: unknown[]): unknown;// needs 1 arguments
+  deleteCollectionItemList (arg: unknown): unknown;// needs 1 arguments
 
-  editCollectionItem(...args: unknown[]): unknown;// needs 2 arguments
+  editCollectionItem (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 
-  getEditPicInfoByPath(...args: unknown[]): unknown;// needs 1 arguments
+  getEditPicInfoByPath (arg: unknown): unknown;// needs 1 arguments
 
-  collectionFastUpload(...args: unknown[]): unknown;// needs 1 arguments
+  collectionFastUpload (arg: unknown): unknown;// needs 1 arguments
 
-  editCollectionItemAfterFastUpload(...args: unknown[]): unknown;// needs 2 arguments
+  editCollectionItemAfterFastUpload (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 
-  createNewCollectionItem(...args: unknown[]): unknown;// needs 1 arguments
+  createNewCollectionItem (arg: unknown): unknown;// needs 1 arguments
 }

--- a/packages/napcat-core/services/NodeIKernelConfigMgrService.ts
+++ b/packages/napcat-core/services/NodeIKernelConfigMgrService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelConfigMgrService {
+  addKernelConfigMgrListener (listener: unknown): number;
+
+  removeKernelConfigMgrListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelDbToolsService.ts
+++ b/packages/napcat-core/services/NodeIKernelDbToolsService.ts
@@ -1,9 +1,9 @@
 export interface NodeIKernelDbToolsService {
 
-  depositDatabase(...args: unknown[]): unknown;
+  depositDatabase (arg: unknown): unknown;
 
-  backupDatabase(...args: unknown[]): unknown;
+  backupDatabase (arg: unknown): unknown;
 
-  retrieveDatabase(...args: unknown[]): unknown;
+  retrieveDatabase (arg: unknown): unknown;
 
 }

--- a/packages/napcat-core/services/NodeIKernelDirectSessionService.ts
+++ b/packages/napcat-core/services/NodeIKernelDirectSessionService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelDirectSessionService {
+  addKernelDirectSessionListener (listener: unknown): number;
+
+  removeKernelDirectSessionListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelECDHService.ts
+++ b/packages/napcat-core/services/NodeIKernelECDHService.ts
@@ -1,3 +1,13 @@
 export interface NodeIKernelECDHService {
   sendOIDBECRequest: (data: Uint8Array) => Promise<Uint8Array>;
+
+  init (): unknown;
+
+  setIsDebug (isDebug: boolean): unknown;
+
+  setGuid (guid: string): unknown;
+
+  sendOIDBRequest (cmd: number, serviceType: number, subCmd: number, data: string, extraData: unknown): Promise<unknown>;
+
+  sendSSORequest (cmd: string, serviceType: number, data: string, extraData: unknown): Promise<unknown>;
 }

--- a/packages/napcat-core/services/NodeIKernelEmojiService.ts
+++ b/packages/napcat-core/services/NodeIKernelEmojiService.ts
@@ -1,0 +1,5 @@
+export interface NodeIKernelEmojiService {
+  getAIGCEmojiList (arg1: unknown, arg2: boolean): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelFeedService.ts
+++ b/packages/napcat-core/services/NodeIKernelFeedService.ts
@@ -1,0 +1,19 @@
+export interface NodeIKernelFeedService {
+  addKernelFeedListener (listener: unknown): number;
+
+  removeKernelFeedListener (listenerId: number): void;
+
+  getChannelDraft (arg1: string, arg2: number): unknown;
+
+  getFeedCount (arg: unknown): unknown;
+
+  getFeedLikeUserList (arg1: unknown, arg2: number): unknown;
+
+  getFeedRichMediaFilePath (arg1: number, arg2: string, arg3: string, arg4: number, arg5: boolean): unknown;
+
+  getJoinedRecommendItems (arg1: unknown, arg2: boolean): unknown;
+
+  setChannelDraft (arg1: string, arg2: string, arg3: number): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelFileAssistantService.ts
+++ b/packages/napcat-core/services/NodeIKernelFileAssistantService.ts
@@ -1,37 +1,41 @@
 import { NodeIKernelFileAssistantListener } from '@/napcat-core/index';
 
 export interface NodeIKernelFileAssistantService {
-  addKernelFileAssistantListener(listener: NodeIKernelFileAssistantListener): unknown;
+  addKernelFileAssistantListener (listener: NodeIKernelFileAssistantListener): unknown;
 
-  removeKernelFileAssistantListener(arg1: unknown[]): unknown;
+  removeKernelFileAssistantListener (arg1: unknown[]): unknown;
 
-  getFileAssistantList(arg1: unknown[]): unknown;
+  getFileAssistantList (arg1: unknown[]): unknown;
 
-  getMoreFileAssistantList(arg1: unknown[]): unknown;
+  getMoreFileAssistantList (arg1: unknown[]): unknown;
 
-  getFileSessionList(): unknown;
+  getFileSessionList (): unknown;
 
-  searchFile(keywords: string[], params: { resultType: number, pageLimit: number }, resultId: number): number;
+  searchFile (keywords: string[], params: { resultType: number, pageLimit: number; }, resultId: number): number;
 
-  resetSearchFileSortType(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  resetSearchFileSortType (arg1: number, arg2: number, arg3: number): unknown;
 
-  searchMoreFile(arg1: unknown[]): unknown;
+  searchMoreFile (arg1: unknown[]): unknown;
 
-  cancelSearchFile(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  cancelSearchFile (arg1: number, arg2: number, arg3: string): unknown;
 
-  downloadFile(fileIds: string[]): { result: number, errMsg: string };
+  downloadFile (fileIds: string[]): { result: number, errMsg: string; };
 
-  forwardFile(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  forwardFile (arg1: unknown, arg2: unknown, arg3: unknown): unknown;
 
-  cancelFileAction(arg1: unknown[]): unknown;
+  cancelFileAction (arg1: unknown[]): unknown;
 
-  retryFileAction(arg1: unknown[]): unknown;
+  retryFileAction (arg1: unknown[]): unknown;
 
-  deleteFile(arg1: unknown[]): unknown;
+  deleteFile (arg1: unknown[]): unknown;
 
-  saveAs(arg1: unknown, arg2: unknown): unknown;
+  saveAs (arg1: unknown, arg2: unknown): unknown;
 
-  saveAsWithRename(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  saveAsWithRename (arg1: string, arg2: string, arg3: string): unknown;
 
-  isNull(): boolean;
+  getFilePathCount (arg: unknown): unknown;
+
+  updateRecentOperateForMsg (arg: unknown): unknown;
+
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelFileBridgeClientService.ts
+++ b/packages/napcat-core/services/NodeIKernelFileBridgeClientService.ts
@@ -1,0 +1,13 @@
+export interface NodeIKernelFileBridgeClientService {
+  addKernelFileBridgeClientListener (listener: unknown): number;
+
+  removeKernelFileBridgeClientListener (listenerId: number): void;
+
+  getPageContent (arg1: boolean, arg2: string): unknown;
+
+  getThumbnail (arg1: boolean, arg2: string, arg3: unknown): unknown;
+
+  searchFolderForFiles (arg1: string, arg2: string, arg3: string): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelFileBridgeHostService.ts
+++ b/packages/napcat-core/services/NodeIKernelFileBridgeHostService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelFileBridgeHostService {
+  addKernelFileBridgeHostListener (listener: unknown): number;
+
+  removeKernelFileBridgeHostListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelFlashTransferService.ts
+++ b/packages/napcat-core/services/NodeIKernelFlashTransferService.ts
@@ -24,13 +24,13 @@ export interface NodeIKernelFlashTransferService {
     seq: number;
   }>; // 2 arg 重点 // 自动上传
 
-  createMergeShareTask (...args: unknown[]): unknown; // 2 arg
+  createMergeShareTask (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  updateFlashTransfer (...args: unknown[]): unknown; // 2 arg
+  updateFlashTransfer (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  getFileSetList (...args: unknown[]): unknown; // 1 arg
+  getFileSetList (arg: unknown): unknown; // 1 arg
 
-  getFileSetListCount (...args: unknown[]): unknown; // 1 arg
+  getFileSetListCount (arg: unknown): unknown; // 1 arg
 
   /**
    * 获取file set 的信息
@@ -50,11 +50,11 @@ export interface NodeIKernelFlashTransferService {
     rsp: FileListResponse;
   }>; // 1 arg 这个方法QQ有bug？？？   并没有，是我参数有问题
 
-  getDownloadedFileCount (...args: unknown[]): unknown; // 1 arg
+  getDownloadedFileCount (arg: unknown): unknown; // 1 arg
 
-  getLocalFileList (...args: unknown[]): unknown; // 3 arg
+  getLocalFileList (arg1: number, arg2: string, arg3: Array<unknown>[]): unknown; // 3 arg
 
-  batchRemoveUserFileSetHistory (...args: unknown[]): unknown; // 1 arg
+  batchRemoveUserFileSetHistory (arg: unknown): unknown; // 1 arg
 
   /**
    * 获取分享链接
@@ -73,26 +73,26 @@ export interface NodeIKernelFlashTransferService {
     fileSetId: string;
   }>; // 1 arg code == share code
 
-  batchRemoveFile (...args: unknown[]): unknown; // 1 arg
+  batchRemoveFile (arg: unknown): unknown; // 1 arg
 
-  checkUploadPathValid (...args: unknown[]): unknown; // 1 arg
+  checkUploadPathValid (arg: unknown): unknown; // 1 arg
 
-  cleanFailedFiles (...args: unknown[]): unknown; // 2 arg
+  cleanFailedFiles (arg1: number, arg2: Array<unknown>[]): unknown; // 2 arg
 
   /**
    * 暂停所有的任务
    */
   resumeAllUnfinishedTasks (): unknown; // 0 arg !!
 
-  addFileSetUploadListener (...args: unknown[]): unknown; // 1 arg
+  addFileSetUploadListener (listener: unknown): unknown; // 1 arg
 
-  removeFileSetUploadListener (...args: unknown[]): unknown; // 1 arg
+  removeFileSetUploadListener (listenerId: unknown): unknown; // 1 arg
 
   /**
    * 开始上传任务  适用于已暂停的
    * @param fileSetId
    */
-  startFileSetUpload (fileSetId: string): void; // 1 arg  并不是新建任务，应该是暂停后的启动
+  startFileSetUpload (fileSetId: unknown): void; // 1 arg  并不是新建任务，应该是暂停后的启动
 
   /**
    * 结束，无法再次启动
@@ -110,27 +110,27 @@ export interface NodeIKernelFlashTransferService {
    * 继续上传
    * @param args
    */
-  resumeFileSetUpload (...args: unknown[]): unknown; // 1 arg  继续
+  resumeFileSetUpload (fileSetId: unknown): unknown; // 1 arg  继续
 
-  pauseFileUpload (...args: unknown[]): unknown; // 1 arg
+  pauseFileUpload (arg: unknown): unknown; // 1 arg
 
-  resumeFileUpload (...args: unknown[]): unknown; // 1 arg
+  resumeFileUpload (arg: unknown): unknown; // 1 arg
 
-  stopFileUpload (...args: unknown[]): unknown; // 1 arg
+  stopFileUpload (arg: unknown): unknown; // 1 arg
 
-  asyncGetThumbnailPath (...args: unknown[]): unknown; // 2 arg
+  asyncGetThumbnailPath (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  setDownLoadDefaultFileDir (...args: unknown[]): unknown; // 1 arg
+  setDownLoadDefaultFileDir (dir: unknown): unknown; // 1 arg
 
-  setFileSetDownloadDir (...args: unknown[]): unknown; // 2 arg
+  setFileSetDownloadDir (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  getFileSetDownloadDir (...args: unknown[]): unknown; // 1 arg
+  getFileSetDownloadDir (arg: unknown): unknown; // 1 arg
 
-  setFlashTransferDir (...args: unknown[]): unknown; // 2 arg
+  setFlashTransferDir (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  addFileSetDownloadListener (...args: unknown[]): unknown; // 1 arg
+  addFileSetDownloadListener (listener: unknown): unknown; // 1 arg
 
-  removeFileSetDownloadListener (...args: unknown[]): unknown; // 1 arg
+  removeFileSetDownloadListener (listenerId: unknown): unknown; // 1 arg
 
   /**
    * 开始下载file set的函数  同开始上传
@@ -154,13 +154,13 @@ export interface NodeIKernelFlashTransferService {
     extraInfo: 0;
   }>; // 2 arg
 
-  startFileListDownLoad (...args: unknown[]): unknown; // 4 arg // 大概率是选择set里面的部分文件进行下载，没必要，不想写
+  startFileListDownLoad (arg1: string, arg2: number, arg3: Array<unknown>[], arg4: unknown): unknown; // 4 arg // 大概率是选择set里面的部分文件进行下载，没必要，不想写
 
-  pauseFileListDownLoad (...args: unknown[]): unknown; // 2 arg
+  pauseFileListDownLoad (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  resumeFileListDownLoad (...args: unknown[]): unknown; // 2 arg
+  resumeFileListDownLoad (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  stopFileListDownLoad (...args: unknown[]): unknown; // 2 arg
+  stopFileListDownLoad (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
   startThumbnailListDownload (fileSetId: string): Promise<GeneralCallResult>; // 1 arg // 缩略图下载
 
@@ -174,31 +174,31 @@ export interface NodeIKernelFlashTransferService {
     expireTimestampSeconds: string;
   }>; // 1 arg
 
-  startFileListDownLoadBySessionId (...args: unknown[]): unknown; // 2 arg
+  startFileListDownLoadBySessionId (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  addFileSetSimpleStatusListener (...args: unknown[]): unknown; // 2 arg
+  addFileSetSimpleStatusListener (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  addFileSetSimpleStatusMonitoring (...args: unknown[]): unknown; // 2 arg
+  addFileSetSimpleStatusMonitoring (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  removeFileSetSimpleStatusMonitoring (...args: unknown[]): unknown; // 2 arg
+  removeFileSetSimpleStatusMonitoring (arg1: unknown, arg2: unknown): unknown; // 2 arg
 
-  removeFileSetSimpleStatusListener (...args: unknown[]): unknown; // 1 arg
+  removeFileSetSimpleStatusListener (arg: unknown): unknown; // 1 arg
 
-  addDesktopFileSetSimpleStatusListener (...args: unknown[]): unknown; // 1 arg
+  addDesktopFileSetSimpleStatusListener (arg: unknown): unknown; // 1 arg
 
-  addDesktopFileSetSimpleStatusMonitoring (...args: unknown[]): unknown; // 1 arg
+  addDesktopFileSetSimpleStatusMonitoring (arg: unknown): unknown; // 1 arg
 
-  removeDesktopFileSetSimpleStatusMonitoring (...args: unknown[]): unknown; // 1 arg
+  removeDesktopFileSetSimpleStatusMonitoring (arg: unknown): unknown; // 1 arg
 
-  removeDesktopFileSetSimpleStatusListener (...args: unknown[]): unknown; // 1 arg
+  removeDesktopFileSetSimpleStatusListener (arg: unknown): unknown; // 1 arg
 
-  addFileSetSimpleUploadInfoListener (...args: unknown[]): unknown; // 1 arg
+  addFileSetSimpleUploadInfoListener (arg: unknown): unknown; // 1 arg
 
-  addFileSetSimpleUploadInfoMonitoring (...args: unknown[]): unknown; // 1 arg
+  addFileSetSimpleUploadInfoMonitoring (arg: unknown): unknown; // 1 arg
 
-  removeFileSetSimpleUploadInfoMonitoring (...args: unknown[]): unknown; // 1 arg
+  removeFileSetSimpleUploadInfoMonitoring (arg: unknown): unknown; // 1 arg
 
-  removeFileSetSimpleUploadInfoListener (...args: unknown[]): unknown; // 1 arg
+  removeFileSetSimpleUploadInfoListener (arg: unknown): unknown; // 1 arg
   /**
    * 发送闪传消息
    * @param sendArgs
@@ -211,9 +211,9 @@ export interface NodeIKernelFlashTransferService {
     };
   }>; // 1 arg  估计是file set id
 
-  addFlashTransferTaskInfoListener (...args: unknown[]): unknown; // 1 arg
+  addFlashTransferTaskInfoListener (listener: unknown): unknown; // 1 arg
 
-  removeFlashTransferTaskInfoListener (...args: unknown[]): unknown; // 1 arg
+  removeFlashTransferTaskInfoListener (listenerId: unknown): unknown; // 1 arg
 
   retrieveLocalLastFailedSetTasksInfo (): unknown; // 0 arg
 
@@ -227,77 +227,77 @@ export interface NodeIKernelFlashTransferService {
     };
   }>; // 1 arg
 
-  getLocalFileListByStatuses (...args: unknown[]): unknown; // 1 arg
+  getLocalFileListByStatuses (arg: unknown): unknown; // 1 arg
 
-  addTransferStateListener (...args: unknown[]): unknown; // 1 arg
+  addTransferStateListener (listener: unknown): unknown; // 1 arg
 
-  removeTransferStateListener (...args: unknown[]): unknown; // 1 arg
+  removeTransferStateListener (listenerId: unknown): unknown; // 1 arg
 
-  getFileSetFirstClusteringList (...args: unknown[]): unknown; // 3 arg
+  getFileSetFirstClusteringList (arg1: number, arg2: string, arg3: number): unknown; // 3 arg
 
-  getFileSetClusteringList (...args: unknown[]): unknown; // 1 arg
+  getFileSetClusteringList (arg: unknown): unknown; // 1 arg
 
-  addFileSetClusteringListListener (...args: unknown[]): unknown; // 1 arg
+  addFileSetClusteringListListener (listener: unknown): unknown; // 1 arg
 
-  removeFileSetClusteringListListener (...args: unknown[]): unknown; // 1 arg
+  removeFileSetClusteringListListener (listenerId: unknown): unknown; // 1 arg
 
-  getFileSetClusteringDetail (...args: unknown[]): unknown; // 1 arg
+  getFileSetClusteringDetail (arg: unknown): unknown; // 1 arg
 
-  doAIOFlashTransferBubbleActionWithStatus (...args: unknown[]): unknown; // 4 arg
+  doAIOFlashTransferBubbleActionWithStatus (arg1: string, arg2: number, arg3: number, arg4: unknown): unknown; // 4 arg
 
-  getFilesTransferProgress (...args: unknown[]): unknown; // 1 arg
+  getFilesTransferProgress (arg: unknown): unknown; // 1 arg
 
-  pollFilesTransferProgress (...args: unknown[]): unknown; // 1 arg
+  pollFilesTransferProgress (arg: unknown): unknown; // 1 arg
 
-  cancelPollFilesTransferProgress (...args: unknown[]): unknown; // 1 arg
+  cancelPollFilesTransferProgress (arg: unknown): unknown; // 1 arg
 
-  checkDownloadStatusBeforeLocalFileOper (...args: unknown[]): unknown; // 3 arg
+  checkDownloadStatusBeforeLocalFileOper (arg1: number, arg2: string, arg3: string): unknown; // 3 arg
 
-  getCompressedFileFolder (...args: unknown[]): unknown; // 1 arg
+  getCompressedFileFolder (arg: unknown): unknown; // 1 arg
 
-  addFolderListener (...args: unknown[]): unknown; // 1 arg
+  addFolderListener (listener: unknown): unknown; // 1 arg
 
-  removeFolderListener (...args: unknown[]): unknown;
+  removeFolderListener (listenerId: unknown): unknown;
 
-  addCompressedFileListener (...args: unknown[]): unknown;
+  addCompressedFileListener (listener: unknown): unknown;
 
-  removeCompressedFileListener (...args: unknown[]): unknown;
+  removeCompressedFileListener (listenerId: unknown): unknown;
 
-  getFileCategoryList (...args: unknown[]): unknown;
+  getFileCategoryList (arg: unknown): unknown;
 
-  addDeviceStatusListener (...args: unknown[]): unknown;
+  addDeviceStatusListener (listener: unknown): unknown;
 
-  removeDeviceStatusListener (...args: unknown[]): unknown;
+  removeDeviceStatusListener (listenerId: unknown): unknown;
 
-  checkDeviceStatus (...args: unknown[]): unknown;
+  checkDeviceStatus (arg: unknown): unknown;
 
-  pauseAllTasks (...args: unknown[]): unknown; // 2 arg
+  pauseAllTasks (arg1: number, arg2: number): unknown; // 2 arg
 
-  resumePausedTasksAfterDeviceStatus (...args: unknown[]): unknown;
+  resumePausedTasksAfterDeviceStatus (arg: unknown): unknown;
 
-  onSystemGoingToSleep (...args: unknown[]): unknown;
+  onSystemGoingToSleep (arg: unknown): unknown;
 
-  onSystemWokeUp (...args: unknown[]): unknown;
+  onSystemWokeUp (arg: unknown): unknown;
 
-  getFileMetas (...args: unknown[]): unknown;
+  getFileMetas (arg: unknown): unknown;
 
-  addDownloadCntStatisticsListener (...args: unknown[]): unknown;
+  addDownloadCntStatisticsListener (listener: unknown): unknown;
 
-  removeDownloadCntStatisticsListener (...args: unknown[]): unknown;
+  removeDownloadCntStatisticsListener (listenerId: unknown): unknown;
 
-  detectPrivacyInfoInPaths (...args: unknown[]): unknown;
+  detectPrivacyInfoInPaths (arg: unknown): unknown;
 
-  getFileThumbnailUrl (...args: unknown[]): unknown;
+  getFileThumbnailUrl (arg: unknown): unknown;
 
-  handleDownloadFinishAfterSaveToAlbum (...args: unknown[]): unknown;
+  handleDownloadFinishAfterSaveToAlbum (arg: unknown): unknown;
 
-  checkBatchFilesDownloadStatus (...args: unknown[]): unknown;
+  checkBatchFilesDownloadStatus (arg: unknown): unknown;
 
-  onCheckAlbumStorageStatusResult (...args: unknown[]): unknown;
+  onCheckAlbumStorageStatusResult (arg: unknown): unknown;
 
-  addFileAlbumStorageListener (...args: unknown[]): unknown;
+  addFileAlbumStorageListener (listener: unknown): unknown;
 
-  removeFileAlbumStorageListener (...args: unknown[]): unknown;
+  removeFileAlbumStorageListener (listenerId: unknown): unknown;
 
-  refreshFolderStatus (...args: unknown[]): unknown;
+  refreshFolderStatus (arg: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelGroupService.ts
+++ b/packages/napcat-core/services/NodeIKernelGroupService.ts
@@ -16,29 +16,29 @@ import { GeneralCallResult } from '@/napcat-core/services/common';
 
 export interface NodeIKernelGroupService {
 
-  modifyGroupExtInfoV2(groupExtInfo: GroupExtInfo, groupExtFilter: GroupExtFilter): Promise<GeneralCallResult &
-    {
-      result: {
-        groupCode: string,
-        result: number
-      }
-    }>;
+  modifyGroupExtInfoV2 (groupExtInfo: GroupExtInfo, groupExtFilter: GroupExtFilter): Promise<GeneralCallResult &
+  {
+    result: {
+      groupCode: string,
+      result: number;
+    };
+  }>;
 
   // --->
   // 待启用 For Next Version 3.2.0
   // isTroopMember ? 0 : 111
-  getGroupMemberMaxNum(groupCode: string, serviceType: number): Promise<unknown>;
+  getGroupMemberMaxNum (groupCode: string, serviceType: number): Promise<unknown>;
 
-  getAllGroupPrivilegeFlag(troopUinList: string[], serviceType: number): Promise<unknown>;
+  getAllGroupPrivilegeFlag (troopUinList: string[], serviceType: number): Promise<unknown>;
   // <---
-  getGroupExt0xEF0Info(enableGroupCodes: string[], bannedGroupCodes: string[], filter: GroupExt0xEF0InfoFilter, forceFetch: boolean):
-  Promise<GeneralCallResult & { result: { groupExtInfos: Map<string, unknown> } }>;
+  getGroupExt0xEF0Info (enableGroupCodes: string[], bannedGroupCodes: string[], filter: GroupExt0xEF0InfoFilter, forceFetch: boolean):
+    Promise<GeneralCallResult & { result: { groupExtInfos: Map<string, unknown>; }; }>;
 
-  kickMemberV2(param: KickMemberV2Req): Promise<GeneralCallResult>;
+  kickMemberV2 (param: KickMemberV2Req): Promise<GeneralCallResult>;
 
-  quitGroupV2(param: { groupCode: string; needDeleteLocalMsg: boolean; }): Promise<GeneralCallResult>;
+  quitGroupV2 (param: { groupCode: string; needDeleteLocalMsg: boolean; }): Promise<GeneralCallResult>;
 
-  getMemberCommonInfo(Req: {
+  getMemberCommonInfo (Req: {
     groupCode: string,
     startUin: string,
     identifyFlag: string,
@@ -54,39 +54,39 @@ export interface NodeIKernelGroupService {
     memberNum: number,
     filterMethod: string,
     onlineFlag: string,
-    realSpecialTitleFlag: number
+    realSpecialTitleFlag: number;
   }): Promise<unknown>;
 
-  getGroupMemberLevelInfo(groupCode: string): Promise<unknown>;
+  getGroupMemberLevelInfo (groupCode: string): Promise<unknown>;
 
-  getGroupInfoForJoinGroup(groupCode: string, needPrivilegeFlag: boolean, serviceType: number): Promise<unknown>;
+  getGroupInfoForJoinGroup (groupCode: string, needPrivilegeFlag: boolean, serviceType: number): Promise<unknown>;
 
-  getGroupHonorList(req: { groupCodes: Array<string> }): Promise<unknown>;
+  getGroupHonorList (req: { groupCodes: Array<string>; }): Promise<unknown>;
 
-  getUinByUids(uins: string[]): Promise<{
+  getUinByUids (uins: string[]): Promise<{
     errCode: number,
     errMsg: string,
-    uins: Map<string, string>
+    uins: Map<string, string>;
   }>;
 
-  getUidByUins(uins: string[]): Promise<{
+  getUidByUins (uins: string[]): Promise<{
     errCode: number,
     errMsg: string,
-    uids: Map<string, string>
+    uids: Map<string, string>;
   }>;
 
-  checkGroupMemberCache(arrayList: Array<string>): Promise<unknown>;
+  checkGroupMemberCache (arrayList: Array<string>): Promise<unknown>;
 
-  getGroupLatestEssenceList(groupCode: string): Promise<unknown>;
+  getGroupLatestEssenceList (groupCode: string): Promise<unknown>;
 
-  shareDigest(Req: {
+  shareDigest (Req: {
     appId: string,
     appType: number,
     msgStyle: number,
     recvUin: string,
     sendType: number,
     clientInfo: {
-      platform: number
+      platform: number;
     },
     richMsg: {
       usingArk: boolean,
@@ -94,122 +94,122 @@ export interface NodeIKernelGroupService {
       summary: string,
       url: string,
       pictureUrl: string,
-      brief: string
-    }
+      brief: string;
+    };
   }): Promise<unknown>;
 
-  isEssenceMsg(req: { groupCode: string, msgRandom: number, msgSeq: number }): Promise<unknown>;
+  isEssenceMsg (req: { groupCode: string, msgRandom: number, msgSeq: number; }): Promise<unknown>;
 
-  queryCachedEssenceMsg(req: { groupCode: string, msgRandom: number, msgSeq: number }): Promise<{ items: Array<unknown> }>;
+  queryCachedEssenceMsg (req: { groupCode: string, msgRandom: number, msgSeq: number; }): Promise<{ items: Array<unknown>; }>;
 
-  fetchGroupEssenceList(req: {
+  fetchGroupEssenceList (req: {
     groupCode: string,
     pageStart: number,
-    pageLimit: number
-  }, Arg: unknown): Promise<unknown>;
+    pageLimit: number;
+  }, Arg: string): Promise<unknown>;
 
-  getAllMemberList(groupCode: string, forceFetch: boolean): Promise<{
+  getAllMemberList (groupCode: string, forceFetch: boolean): Promise<{
     errCode: number,
     errMsg: string,
     result: {
       ids: Array<{
         uid: string,
-        index: number// 0
+        index: number;// 0
       }>,
       infos: Map<string, GroupMember>,
       finish: true,
-      hasRobot: false
-    }
+      hasRobot: false;
+    };
   }>;
 
-  setHeader(uid: string, path: string): Promise<GeneralCallResult>;
+  setHeader (uid: string, path: string): Promise<GeneralCallResult>;
 
-  addKernelGroupListener(listener: NodeIKernelGroupListener): number;
+  addKernelGroupListener (listener: NodeIKernelGroupListener): number;
 
-  removeKernelGroupListener(listenerId: number): void;
+  removeKernelGroupListener (listenerId: number): void;
 
-  createMemberListScene(groupCode: string, scene: string): string;
+  createMemberListScene (groupCode: string, scene: string): string;
 
-  destroyMemberListScene(SceneId: string): void;
+  destroyMemberListScene (SceneId: string): void;
 
-  getNextMemberList(sceneId: string, groupMemberInfoListId: { index: number, uid: string } | undefined, num: number): Promise<{
+  getNextMemberList (sceneId: string, groupMemberInfoListId: { index: number, uid: string; } | undefined, num: number): Promise<{
     errCode: number,
     errMsg: string,
-    result: { ids: string[], infos: Map<string, GroupMember>, finish: boolean, hasRobot: boolean }
+    result: { ids: string[], infos: Map<string, GroupMember>, finish: boolean, hasRobot: boolean; };
   }>;
 
-  getPrevMemberList(): unknown;
+  getPrevMemberList (): unknown;
 
-  monitorMemberList(): unknown;
+  monitorMemberList (): unknown;
 
-  searchMember(sceneId: string, keywords: string[]): unknown;
+  searchMember (sceneId: string, keywords: string[]): unknown;
 
-  getMemberInfo(group_id: string, uids: string[], forceFetch: boolean): Promise<GeneralCallResult>;
+  getMemberInfo (group_id: string, uids: string[], forceFetch: boolean): Promise<GeneralCallResult>;
 
-  kickMember(groupCode: string, memberUids: string[], refuseForever: boolean, kickReason: string): Promise<void>;
+  kickMember (groupCode: string, memberUids: string[], refuseForever: boolean, kickReason: string): Promise<void>;
 
-  modifyMemberRole(groupCode: string, uid: string, role: NTGroupMemberRole): void;
+  modifyMemberRole (groupCode: string, uid: string, role: NTGroupMemberRole): void;
 
-  modifyMemberCardName(groupCode: string, uid: string, cardName: string): void;
+  modifyMemberCardName (groupCode: string, uid: string, cardName: string): void;
 
-  getTransferableMemberInfo(groupCode: string): unknown;// 获取整个群的
+  getTransferableMemberInfo (groupCode: string): unknown;// 获取整个群的
 
-  transferGroup(uid: string): void;
+  transferGroup (uid: string): void;
 
-  getGroupList(force: boolean): Promise<GeneralCallResult>;
+  getGroupList (force: boolean): Promise<GeneralCallResult>;
 
-  getGroupExtList(force: boolean): Promise<GeneralCallResult>;
+  getGroupExtList (force: boolean): Promise<GeneralCallResult>;
 
-  getGroupDetailInfo(groupCode: string, groupInfoSource: GroupInfoSource): Promise<GeneralCallResult>;
+  getGroupDetailInfo (groupCode: string, groupInfoSource: GroupInfoSource): Promise<GeneralCallResult>;
 
-  getMemberExtInfo(param: GroupExtParam): Promise<unknown>;// req
+  getMemberExtInfo (param: GroupExtParam): Promise<unknown>;// req
 
-  getGroupAllInfo(groupId: string, sourceId: number): Promise<unknown>;
+  getGroupAllInfo (groupId: string, sourceId: number): Promise<unknown>;
 
-  getDiscussExistInfo(): unknown;
+  getDiscussExistInfo (): unknown;
 
-  getGroupConfMember(): unknown;
+  getGroupConfMember (): unknown;
 
-  getGroupMsgMask(): unknown;
+  getGroupMsgMask (): unknown;
 
-  getGroupPortrait(): void;
+  getGroupPortrait (): void;
 
-  modifyGroupName(groupCode: string, groupName: string, isNormalMember: boolean): Promise<GeneralCallResult>;
+  modifyGroupName (groupCode: string, groupName: string, isNormalMember: boolean): Promise<GeneralCallResult>;
 
-  modifyGroupRemark(groupCode: string, remark: string): Promise<GeneralCallResult>;
+  modifyGroupRemark (groupCode: string, remark: string): Promise<GeneralCallResult>;
 
-  modifyGroupDetailInfo(groupCode: string, arg: unknown): void;
+  modifyGroupDetailInfo (groupCode: string, arg: unknown): void;
 
   // 第二个参数在大多数情况为0 设置群成员权限 例如上传群文件权限和群成员付费/加入邀请加入时为8
-  modifyGroupDetailInfoV2(param: GroupDetailInfoV2Param, arg: number): Promise<GeneralCallResult>;
+  modifyGroupDetailInfoV2 (param: GroupDetailInfoV2Param, arg: number): Promise<GeneralCallResult>;
 
-  setGroupMsgMask(groupCode: string, arg: unknown): void;
+  setGroupMsgMask (groupCode: string, arg: unknown): void;
 
-  changeGroupShieldSettingTemp(groupCode: string, arg: unknown): void;
+  changeGroupShieldSettingTemp (groupCode: string, arg: unknown): void;
 
-  inviteToGroup(arg: unknown): void;
+  inviteToGroup (arg: unknown): void;
 
-  inviteMembersToGroup(args: unknown[]): void;
+  inviteMembersToGroup (args: unknown[]): void;
 
-  inviteMembersToGroupWithMsg(args: unknown): void;
+  inviteMembersToGroupWithMsg (args: unknown): void;
 
-  createGroup(arg: unknown): void;
+  createGroup (arg: unknown): void;
 
-  createGroupWithMembers(arg: unknown): void;
+  createGroupWithMembers (arg: unknown): void;
 
-  quitGroup(groupCode: string): void;
+  quitGroup (groupCode: string): void;
 
-  destroyGroup(groupCode: string): void;
+  destroyGroup (groupCode: string): void;
 
-  getSingleScreenNotifies(doubt: boolean, startSeq: string, count: number): Promise<GeneralCallResult>;
+  getSingleScreenNotifies (doubt: boolean, startSeq: string, count: number): Promise<GeneralCallResult>;
 
-  clearGroupNotifies(groupCode: string): void;
+  clearGroupNotifies (groupCode: string): void;
 
-  getGroupNotifiesUnreadCount(doubt: boolean): Promise<GeneralCallResult>;
+  getGroupNotifiesUnreadCount (doubt: boolean): Promise<GeneralCallResult>;
 
-  clearGroupNotifiesUnreadCount(doubt: boolean): void;
+  clearGroupNotifiesUnreadCount (doubt: boolean): void;
 
-  operateSysNotify(
+  operateSysNotify (
     doubt: boolean,
     operateMsg: {
       operateType: NTGroupRequestOperateTypes,
@@ -217,80 +217,277 @@ export interface NodeIKernelGroupService {
         seq: string,
         type: GroupNotifyMsgType,
         groupCode: string,
-        postscript: string
-      }
+        postscript: string;
+      };
     }): Promise<void>;
 
-  setTop(groupCode: string, isTop: boolean): void;
+  setTop (groupCode: string, isTop: boolean): void;
 
-  getGroupBulletin(groupCode: string): unknown;
+  getGroupBulletin (groupCode: string): unknown;
 
-  deleteGroupBulletin(groupCode: string, seq: string, noticeId: string): void;
+  deleteGroupBulletin (groupCode: string, seq: string, noticeId: string): void;
 
-  publishGroupBulletin(groupCode: string, pskey: string, data: unknown): Promise<GeneralCallResult>;
+  publishGroupBulletin (groupCode: string, pskey: string, data: unknown): Promise<GeneralCallResult>;
 
-  publishInstructionForNewcomers(groupCode: string, arg: unknown): void;
+  publishInstructionForNewcomers (groupCode: string, arg: unknown): void;
 
-  uploadGroupBulletinPic(groupCode: string, pskey: string, imagePath: string): Promise<GeneralCallResult & {
+  uploadGroupBulletinPic (groupCode: string, pskey: string, imagePath: string): Promise<GeneralCallResult & {
     errCode: number;
     picInfo?: {
       id: string,
       width: number,
-      height: number
-    }
+      height: number;
+    };
   }>;
 
-  downloadGroupBulletinRichMedia(groupCode: string): unknown;
+  downloadGroupBulletinRichMedia (groupCode: string): unknown;
 
-  getGroupBulletinList(groupCode: string): unknown;
+  getGroupBulletinList (groupCode: string): unknown;
 
-  getGroupStatisticInfo(groupCode: string): unknown;
+  getGroupStatisticInfo (groupCode: string): unknown;
 
-  getGroupRemainAtTimes(groupCode: string): Promise<Omit<GeneralCallResult, 'result'> & {
+  getGroupRemainAtTimes (groupCode: string): Promise<Omit<GeneralCallResult, 'result'> & {
     errCode: number,
     atInfo: {
-      canAtAll: boolean
-      RemainAtAllCountForUin: number
-      RemainAtAllCountForGroup: number
-      atTimesMsg: string
-      canNotAtAllMsg: ''
-    }
+      canAtAll: boolean;
+      RemainAtAllCountForUin: number;
+      RemainAtAllCountForGroup: number;
+      atTimesMsg: string;
+      canNotAtAllMsg: '';
+    };
   }>;
 
-  getJoinGroupNoVerifyFlag(groupCode: string): unknown;
+  getJoinGroupNoVerifyFlag (groupCode: string): unknown;
 
-  getGroupArkInviteState(groupCode: string): unknown;
+  getGroupArkInviteState (groupCode: string): unknown;
 
-  reqToJoinGroup(groupCode: string, arg: unknown): void;
+  reqToJoinGroup (groupCode: string, arg: unknown): void;
 
-  setGroupShutUp(groupCode: string, shutUp: boolean): Promise<GeneralCallResult>;
+  setGroupShutUp (groupCode: string, shutUp: boolean): Promise<GeneralCallResult>;
 
-  getGroupShutUpMemberList(groupCode: string): Promise<GeneralCallResult>;
+  getGroupShutUpMemberList (groupCode: string): Promise<GeneralCallResult>;
 
-  setMemberShutUp(groupCode: string, memberTimes: { uid: string, timeStamp: number }[]): Promise<GeneralCallResult>;
+  setMemberShutUp (groupCode: string, memberTimes: { uid: string, timeStamp: number; }[]): Promise<GeneralCallResult>;
 
-  getGroupRecommendContactArkJson(groupCode: string): Promise<GeneralCallResult & { arkJson: string }>;
+  getGroupRecommendContactArkJson (groupCode: string): Promise<GeneralCallResult & { arkJson: string; }>;
 
-  getJoinGroupLink(param: {
+  getJoinGroupLink (param: {
     groupCode: string,
     srcId: number, // 73
     needShortUrl: boolean, // true
-    additionalParam: string// ''
-  }): Promise<GeneralCallResult & { url?: string }>;
+    additionalParam: string;// ''
+  }): Promise<GeneralCallResult & { url?: string; }>;
 
-  modifyGroupExtInfo(groupCode: string, arg: unknown): void;
+  modifyGroupExtInfo (groupCode: string, arg: unknown): void;
 
-  addGroupEssence(param: {
-    groupCode: string
+  addGroupEssence (param: {
+    groupCode: string;
     msgRandom: number,
-    msgSeq: number
+    msgSeq: number;
   }): Promise<unknown>;
 
-  removeGroupEssence(param: {
-    groupCode: string
+  removeGroupEssence (param: {
+    groupCode: string;
     msgRandom: number,
-    msgSeq: number
+    msgSeq: number;
   }): Promise<unknown>;
 
-  isNull(): boolean;
+  isNull (): boolean;
+
+  // --- Methods from IDA binary analysis ---
+  clearGroupNotifyLocalUnreadCount (groupCode: string, arg: number): unknown;
+
+  getCardAppList (groupCode: string, arg: boolean): unknown;
+
+  getGroupBulletinDetail (arg1: string, arg2: string, arg3: string, arg4: boolean): unknown;
+
+  getGroupBulletinReadUsers (arg1: string, arg2: string, arg3: string, arg4: number, arg5: number, arg6: number): unknown;
+
+  getGroupDetailInfoByFilter (arg1: unknown, arg2: number, arg3: number, arg4: boolean): unknown;
+
+  getGroupDetailInfoForMqq (arg1: string, arg2: number, arg3: number, arg4: boolean): unknown;
+
+  getMemberInfoForMqq (arg1: string, arg2: Array<unknown>[], arg3: boolean): unknown;
+
+  getMemberInfoForMqqV2 (arg1: string, arg2: Array<unknown>[], arg3: boolean, arg4: string): unknown;
+
+  getRecGroups (arg1: string, arg2: unknown, arg3: string): unknown;
+
+  getSingleScreenNotifiesV2 (arg1: boolean, arg2: string, arg3: number, arg4: number): unknown;
+
+  modifyWxNotifyStatus (arg1: string, arg2: number): unknown;
+
+  operateSpecialFocus (arg1: string, arg2: Array<unknown>[], arg3: number): unknown;
+
+  remindGroupBulletinRead (arg1: string, arg2: string, arg3: string): unknown;
+
+  transferGroupV2 (arg1: string, arg2: string, arg3: string): unknown;
+
+  operateSysNotifyV2 (arg1: unknown, arg2: unknown): Promise<unknown>;
+
+  getAllMemberListV2 (groupCode: string, arg: unknown): unknown;
+
+  createGroupV2 (arg1: unknown, arg2: unknown): unknown;
+
+  modifyGroupExtInfoV2 (groupExtInfo: GroupExtInfo, groupExtFilter: GroupExtFilter): Promise<GeneralCallResult & {
+    result: { groupCode: string, result: number; };
+  }>;
+
+  modifyGroupDetailInfoV2 (param: GroupDetailInfoV2Param, arg: number): Promise<GeneralCallResult>;
+
+  setGroupMsgMaskV2 (arg1: unknown, arg2: unknown): unknown;
+
+  getGroupSquareRedpointInfo (arg1: unknown, arg2: unknown): unknown;
+
+  getGroupSquareHomeHead (arg1: unknown, arg2: unknown): unknown;
+
+  getCapsuleApp (arg1: unknown, arg2: unknown): unknown;
+
+  getCapsuleAppPro (arg1: unknown, arg2: unknown): unknown;
+
+  getMemberInfoCache (arg1: unknown, arg2: unknown): unknown;
+
+  getGroupSecLevelInfo (arg1: unknown, arg2: unknown): unknown;
+
+  getSubGroupInfo (arg: unknown): unknown;
+
+  getSwitchStatusForEssenceMsg (arg: unknown): unknown;
+
+  getTeamUpDetail (arg: unknown): unknown;
+
+  getTeamUpList (arg: unknown): unknown;
+
+  getTeamUpMembers (arg: unknown): unknown;
+
+  getTeamUpTemplateList (arg: unknown): unknown;
+
+  getTopicPage (arg1: string, arg2: string, arg3: string, arg4: string): unknown;
+
+  getTopicRecall (arg: unknown): unknown;
+
+  getWxNotifyStatus (arg: unknown): unknown;
+
+  getGroupPayToJoinStatus (arg: unknown): unknown;
+
+  getGroupSeqAndJoinTimeForGrayTips (arg: unknown): unknown;
+
+  getGroupTagRecords (arg: unknown): unknown;
+
+  getGroupBindGuilds (arg: unknown): unknown;
+
+  getGroupFlagForThirdApp (arg: unknown): unknown;
+
+  getGroupMsgLimitFreq (arg: unknown): unknown;
+
+  getGroupMedalList (arg: unknown): unknown;
+
+  getGroupDBVersion (arg: unknown): unknown;
+
+  getGroupInviteNoAuthLimitNum (arg: unknown): unknown;
+
+  getAIOBindGuildInfo (arg: unknown): unknown;
+
+  getAppCenter (arg: unknown): unknown;
+
+  getAICommonVoice (arg: unknown): unknown;
+
+  groupBlacklistDelApply (arg: unknown): unknown;
+
+  groupBlacklistGetAllApply (arg: unknown): unknown;
+
+  fetchGroupNotify (arg: unknown): unknown;
+
+  queryJoinGroupCanNoVerify (arg: unknown): unknown;
+
+  halfScreenPullNotice (arg: unknown): unknown;
+
+  halfScreenReportClick (arg: unknown): unknown;
+
+  joinGroup (arg: unknown): unknown;
+
+  listAllAIVoice (arg: unknown): unknown;
+
+  miniAppGetGroupInfo (arg: unknown): unknown;
+
+  postTeamUp (arg: unknown): unknown;
+
+  queryAIOBindGuild (arg: unknown): unknown;
+
+  removeGroupFromGroupList (arg: unknown): unknown;
+
+  saveAIVoice (arg: unknown): unknown;
+
+  setActiveExtGroup (arg: unknown): unknown;
+
+  setAIOBindGuild (arg: unknown): unknown;
+
+  setCapsuleSwitch (arg: unknown): unknown;
+
+  setGroupAppList (arg: unknown): unknown;
+
+  setGroupGeoInfo (arg: unknown): unknown;
+
+  setGroupRelationToGuild (arg: unknown): unknown;
+
+  setRcvJoinVerifyMsg (arg: unknown): unknown;
+
+  teamUpCreateGroup (arg: unknown): unknown;
+
+  teamUpInviteToGroup (arg: unknown): unknown;
+
+  teamUpRequestToJoin (arg: unknown): unknown;
+
+  teamUpSubmitDeadline (arg: unknown): unknown;
+
+  topicFeedback (arg: unknown): unknown;
+
+  topicReport (arg: unknown): unknown;
+
+  shareTopic (arg: unknown): unknown;
+
+  unbindAllGuilds (arg: unknown): unknown;
+
+  updateGroupInfoByMqq (arg: unknown): unknown;
+
+  updateMemberInfoByMqq (arg: unknown): unknown;
+
+  updateTeamUp (arg: unknown): unknown;
+
+  applyTeamUp (arg: unknown): unknown;
+
+  deleteTeamUp (arg: unknown): unknown;
+
+  getFindPageRecommendGroup (arg: unknown): unknown;
+
+  getTransferableMemberInfo (groupCode: string): unknown;
+
+  createGroupProfileShare (arg: unknown): unknown;
+
+  destroyMemberListScene (sceneId: string): void;
+
+  clearGroupSquareRedpointCache (arg: unknown): unknown;
+
+  checkGroupMemberCache (arrayList: Array<string>): Promise<unknown>;
+
+  cleanCapsuleCache (arg: unknown): unknown;
+
+  downloadGroupBulletinRichMedia (groupCode: string): unknown;
+
+  kickMemberV2 (param: KickMemberV2Req): Promise<GeneralCallResult>;
+
+  destroyGroupV2 (arg: unknown): unknown;
+
+  quitGroupV2 (param: { groupCode: string; needDeleteLocalMsg: boolean; }): Promise<GeneralCallResult>;
+
+  inviteToGroupV2 (arg: unknown): unknown;
+
+  getGroupMsgMask (): unknown;
+
+  batchQueryCachedGroupDetailInfo (arg: unknown): unknown;
+
+  getGroupMemberLevelInfo (groupCode: string): Promise<unknown>;
+
+  getIllegalMemberList (arg: unknown): unknown;
+
+  getGroupRecommendContactArkJsonToWechat (arg: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelGroupTabService.ts
+++ b/packages/napcat-core/services/NodeIKernelGroupTabService.ts
@@ -1,0 +1,9 @@
+export interface NodeIKernelGroupTabService {
+  addListener (listener: unknown): number;
+
+  removeListener (listenerId: number): void;
+
+  getGroupTab (arg1: unknown, arg2: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelHandOffService.ts
+++ b/packages/napcat-core/services/NodeIKernelHandOffService.ts
@@ -1,0 +1,15 @@
+export interface NodeIKernelHandOffService {
+  addKernelHandOffListener (listener: unknown): number;
+
+  removeKernelHandOffListener (listenerId: number): void;
+
+  changeHandOffActivities (arg: unknown): unknown;
+
+  deleteRecentHandOffActivities (arg: unknown): unknown;
+
+  getHandOffActivities (arg: unknown): unknown;
+
+  sendCapsulePanelActivities (arg1: string, arg2: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelLiteBusinessService.ts
+++ b/packages/napcat-core/services/NodeIKernelLiteBusinessService.ts
@@ -1,0 +1,19 @@
+export interface NodeIKernelLiteBusinessService {
+  addListener (listener: unknown): number;
+
+  removeListener (listenerId: number): void;
+
+  clearLiteBusiness (arg1: string, arg2: unknown): unknown;
+
+  clickLiteAction (arg1: unknown, arg2: unknown): unknown;
+
+  exposeLiteAction (arg1: unknown, arg2: unknown): unknown;
+
+  getLiteBusiness (arg1: string, arg2: unknown): unknown;
+
+  getRevealTofuAuthority (arg: unknown): unknown;
+
+  recentRevealExposure (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelLockService.ts
+++ b/packages/napcat-core/services/NodeIKernelLockService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelLockService {
+  addKernelLockListener (listener: unknown): number;
+
+  removeKernelLockListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelLoginService.ts
+++ b/packages/napcat-core/services/NodeIKernelLoginService.ts
@@ -63,7 +63,9 @@ export interface QuickLoginResult {
 export interface NodeIKernelLoginService {
   getMsfStatus: () => number;
 
-  setLoginMiscData (arg0: string, value: string): unknown;
+  setLoginMiscData (key: string, value: string): unknown;
+
+  getLoginMiscData (key: string): Promise<GeneralCallResult & { value: string; }>;
 
   getMachineGuid (): string;
 
@@ -73,14 +75,12 @@ export interface NodeIKernelLoginService {
 
   addKernelLoginListener (listener: NodeIKernelLoginListener): number;
 
-  removeKernelLoginListener (listener: number): void;
+  removeKernelLoginListener (listenerId: number): void;
 
   initConfig (config: LoginInitConfig): void;
 
-  getLoginMiscData (data: string): Promise<GeneralCallResult & { value: string; }>;
-
   getLoginList (): Promise<{
-    result: number,  // 0是ok
+    result: number,
     LocalLoginInfoList: LoginListItem[];
   }>;
 
@@ -89,4 +89,32 @@ export interface NodeIKernelLoginService {
   passwordLogin (param: PasswordLoginArgType): Promise<QuickLoginResult>;
 
   getQRCodePicture (): boolean;
+
+  destroy (): unknown;
+
+  cancel (): unknown;
+
+  abortPolling (): unknown;
+
+  startPolling (): unknown;
+
+  deleteLoginInfo (arg: unknown): unknown;
+
+  isHasLoginInfo (uin: string): boolean;
+
+  loadNoLoginUnitedConfig (arg: unknown): unknown;
+
+  loginUnusualDevice (arg: unknown): unknown;
+
+  registerUnitedConfigPushGroupList (groupList: unknown): unknown;
+
+  resetLoginInfo (arg: unknown): unknown;
+
+  setAutoLogin (arg: unknown): unknown;
+
+  setRemerberPwd (remember: boolean): unknown;
+
+  online (): unknown;
+
+  offline (): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelMSFService.ts
+++ b/packages/napcat-core/services/NodeIKernelMSFService.ts
@@ -6,6 +6,9 @@ enum ProxyType {
 }
 export interface NodeIKernelMSFService {
   getServerTime (): string;
+  getMsfStatus (): number;
+  online (): unknown;
+  offline (): unknown;
   setNetworkProxy (param: {
     userName: string,
     userPwd: string,
@@ -50,4 +53,5 @@ export interface NodeIKernelMSFService {
     accountType: number,
     transInfoMap: Map<string, unknown>;
   }): Promise<Buffer>;
+  onMsfPushForTesting (arg1: unknown, arg2: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelMiniAppService.ts
+++ b/packages/napcat-core/services/NodeIKernelMiniAppService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelMiniAppService {
+  addKernelMiniAppListener (listener: unknown): number;
+
+  removeKernelMiniAppListener (listenerId: number): void;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelMsgBackupService.ts
+++ b/packages/napcat-core/services/NodeIKernelMsgBackupService.ts
@@ -1,27 +1,27 @@
 export interface NodeIKernelMsgBackupService {
-  addKernelMsgBackupListener(listener: unknown): number;
+  addKernelMsgBackupListener (listener: unknown): number;
 
-  removeKernelMsgBackupListener(listenerId: number): void;
+  removeKernelMsgBackupListener (listenerId: number): void;
 
-  getMsgBackupLocation(...args: unknown[]): unknown;// needs 0 arguments
+  getMsgBackupLocation (): unknown;// needs 0 arguments
 
-  setMsgBackupLocation(...args: unknown[]): unknown;// needs 1 arguments
+  setMsgBackupLocation (arg: unknown): unknown;// needs 1 arguments
 
-  requestMsgBackup(...args: unknown[]): unknown;// needs 0 arguments
+  requestMsgBackup (): unknown;// needs 0 arguments
 
-  requestMsgRestore(...args: unknown[]): unknown;// needs 1 arguments
+  requestMsgRestore (arg: unknown): unknown;// needs 1 arguments
 
-  requestMsgMigrate(...args: unknown[]): unknown;// needs 1 arguments
+  requestMsgMigrate (arg: unknown): unknown;// needs 1 arguments
 
-  getLocalStorageBackup(...args: unknown[]): unknown;// needs 0 arguments
+  getLocalStorageBackup (): unknown;// needs 0 arguments
 
-  deleteLocalBackup(...args: unknown[]): unknown;// needs 1 arguments
+  deleteLocalBackup (arg: unknown): unknown;// needs 1 arguments
 
-  clearCache(...args: unknown[]): unknown;// needs 0 arguments
+  clearCache (): unknown;// needs 0 arguments
 
-  start(...args: unknown[]): unknown;// needs 1 arguments
+  start (arg: unknown): unknown;// needs 1 arguments
 
-  stop(...args: unknown[]): unknown;// needs 1 arguments
+  stop (arg: unknown): unknown;// needs 1 arguments
 
-  pause(...args: unknown[]): unknown;// needs 2 arguments
+  pause (arg1: unknown, arg2: unknown): unknown;// needs 2 arguments
 }

--- a/packages/napcat-core/services/NodeIKernelMsgService.ts
+++ b/packages/napcat-core/services/NodeIKernelMsgService.ts
@@ -1,7 +1,7 @@
-import { ElementType, MessageElement, Peer, RawMessage, FileElement, SendMessageElement } from '@/napcat-core/types';
+import { ElementType, MessageElement, Peer, RawMessage, FileElement, SendMessageElement, AvRecordElement, TofuRecordElement } from '@/napcat-core/types';
 import { NodeIKernelMsgListener } from '@/napcat-core/listeners/NodeIKernelMsgListener';
 import { GeneralCallResult } from '@/napcat-core/services/common';
-import { MsgReqType, QueryMsgsParams, TmpChatInfoApi } from '@/napcat-core/types/msg';
+import { MsgReqType, QueryMsgsParams, TmpChatInfoApi, MsgTypeFilter, MsgIdentity, SgrpStreamParams, GrayTipJsonInfo, ForwardFileInfo, LocalGrayTipInfo, TokenInfo, BackGroundInfo } from '@/napcat-core/types/msg';
 
 export interface NodeIKernelMsgService {
   buildMultiForwardMsg (req: { srcMsgIds: Array<string>, srcContact: Peer; }): Promise<GeneralCallResult & { rspInfo: { elements: unknown; }; }>;
@@ -10,21 +10,21 @@ export interface NodeIKernelMsgService {
 
   addKernelMsgListener (nodeIKernelMsgListener: NodeIKernelMsgListener): number;
 
-  sendMsg (msgId: string, peer: Peer, msgElements: SendMessageElement[], map: Map<unknown, unknown>): Promise<GeneralCallResult>;
+  sendMsg (msgId: string, peer: Peer, msgElements: SendMessageElement[], map: Map<number, unknown>): Promise<GeneralCallResult>;
 
   recallMsg (peer: Peer, msgIds: string[]): Promise<GeneralCallResult>;
 
-  addKernelMsgImportToolListener (arg: unknown): unknown;
+  addKernelMsgImportToolListener (listener: unknown): string;
 
-  removeKernelMsgListener (args: unknown): unknown;
+  removeKernelMsgListener (listenerId: string): void;
 
-  addKernelTempChatSigListener (...args: unknown[]): unknown;
+  addKernelTempChatSigListener (listener: unknown): string;
 
-  removeKernelTempChatSigListener (...args: unknown[]): unknown;
+  removeKernelTempChatSigListener (listenerId: string): void;
 
   setAutoReplyTextList (AutoReplyText: Array<unknown>, i2: number): unknown;
 
-  getAutoReplyTextList (...args: unknown[]): unknown;
+  getAutoReplyTextList (): unknown;
 
   getOnLineDev (): void;
 
@@ -52,85 +52,85 @@ export interface NodeIKernelMsgService {
 
   downloadOnlineStatusCommonByUrl (arg0: string, arg1: string): unknown;
 
-  setToken (arg: unknown): unknown;
+  setToken (tokenInfo: TokenInfo): Promise<GeneralCallResult>;
 
   switchForeGround (): unknown;
 
-  switchBackGround (arg: unknown): unknown;
+  switchBackGround (info: BackGroundInfo): Promise<GeneralCallResult>;
 
   setTokenForMqq (token: string): unknown;
 
-  switchForeGroundForMqq (...args: unknown[]): unknown;
+  switchForeGroundForMqq (data: string | Uint8Array): Promise<GeneralCallResult>;
 
-  switchBackGroundForMqq (...args: unknown[]): unknown;
+  switchBackGroundForMqq (data: string | Uint8Array): Promise<GeneralCallResult>;
 
-  getMsgSetting (...args: unknown[]): unknown;
+  getMsgSetting (): unknown;
 
-  setMsgSetting (...args: unknown[]): unknown;
+  setMsgSetting (setting: unknown): unknown;
 
-  addSendMsg (...args: unknown[]): unknown;
+  addSendMsg (msgId: string, peer: Peer, msgElements: SendMessageElement[], map: Map<number, unknown>): unknown;
 
   cancelSendMsg (peer: Peer, msgId: string): Promise<void>;
 
   switchToOfflineSendMsg (peer: Peer, MsgId: string): unknown;
 
-  reqToOfflineSendMsg (...args: unknown[]): unknown;
+  reqToOfflineSendMsg (peer: Peer, msgId: string): unknown;
 
   refuseReceiveOnlineFileMsg (peer: Peer, MsgId: string): unknown;
 
   resendMsg (peer: Peer, msgId: string): Promise<void>;
 
-  recallMsg (...args: unknown[]): unknown;
+  reeditRecallMsg (peer: Peer, msgId: string): unknown;
 
-  reeditRecallMsg (...args: unknown[]): unknown;
+  forwardMsg (msgIds: string[], peer: Peer, dstPeers: Peer[], commentElements: unknown): Promise<GeneralCallResult>;
 
-  forwardMsg (...args: unknown[]): Promise<GeneralCallResult>;
+  forwardMsgWithComment (msgIds: string[], srcContact: Peer, dstContacts: Peer[], commentElements: Array<unknown>, arg5: unknown): unknown;
 
-  forwardMsgWithComment (...args: unknown[]): unknown;
+  forwardSubMsgWithComment (msgIds: string[], subMsgIds: string[], srcContact: Peer, dstContacts: Peer[], commentElements: Array<unknown>, arg6: unknown): unknown;
 
-  forwardSubMsgWithComment (...args: unknown[]): unknown;
+  forwardRichMsgInVist (richMsgInfos: Array<unknown>, dstContacts: Peer[]): unknown;
 
-  forwardRichMsgInVist (...args: unknown[]): unknown;
+  forwardFile (fileInfo: ForwardFileInfo, peer: Peer): unknown;
 
-  forwardFile (...args: unknown[]): unknown;
+  multiForwardMsg (peer: Peer, srcContact: Peer, msgIds: string[]): unknown;
 
-  multiForwardMsg (...args: unknown[]): unknown;
+  multiForwardMsgWithComment (msgInfos: Array<unknown>, srcContact: Peer, dstContact: Peer, commentElements: Array<unknown>, arg5: unknown): unknown;
 
-  multiForwardMsgWithComment (...args: unknown[]): unknown;
+  deleteRecallMsg (peer: Peer, msgId: string): unknown;
 
-  deleteRecallMsg (...args: unknown[]): unknown;
+  deleteRecallMsgForLocal (peer: Peer, msgId: string): unknown;
 
-  deleteRecallMsgForLocal (...args: unknown[]): unknown;
+  addLocalGrayTipMsg (peer: Peer, grayTipInfo: LocalGrayTipInfo, isUnread: boolean): unknown;
 
-  addLocalGrayTipMsg (...args: unknown[]): unknown;
+  addLocalJsonGrayTipMsg (arg1: Peer, arg2: GrayTipJsonInfo, arg3: boolean, arg4: boolean): unknown;
 
-  addLocalJsonGrayTipMsg (...args: unknown[]): unknown;
+  addLocalJsonGrayTipMsgExt (arg1: Peer, arg2: MsgIdentity, arg3: GrayTipJsonInfo, arg4: boolean, arg5: boolean): unknown;
 
-  addLocalJsonGrayTipMsgExt (...args: unknown[]): unknown;
+  IsLocalJsonTipValid (tipType: number): boolean;
 
-  IsLocalJsonTipValid (...args: unknown[]): unknown;
+  addLocalAVRecordMsg (peer: Peer, avRecord: AvRecordElement): unknown;
 
-  addLocalAVRecordMsg (...args: unknown[]): unknown;
-
-  addLocalTofuRecordMsg (...args: unknown[]): unknown;
+  addLocalTofuRecordMsg (peer: Peer, tofuRecord: TofuRecordElement): unknown;
 
   addLocalRecordMsg (Peer: Peer, msgId: string, ele: MessageElement, attr: Array<unknown> | number, front: boolean): Promise<unknown>;
 
+  addLocalRecordMsgWithExtInfos (peer: Peer, msgId: string, extInfos: unknown): unknown;
+
   deleteMsg (Peer: Peer, msgIds: Array<string>): Promise<unknown>;
 
-  updateElementExtBufForUI (...args: unknown[]): unknown;
+  updateElementExtBufForUI (arg1: Peer, arg2: string, arg3: string, arg4: string | Uint8Array): unknown;
 
-  updateMsgRecordExtPbBufForUI (...args: unknown[]): unknown;
+  updateMsgRecordExtPbBufForUI (arg1: Peer, arg2: string, arg3: unknown): unknown;
 
-  startMsgSync (...args: unknown[]): unknown;
+  startMsgSync (): unknown;
 
-  startGuildMsgSync (...args: unknown[]): unknown;
+  startGuildMsgSync (): unknown;
 
-  isGuildChannelSync (...args: unknown[]): unknown;
+  isGuildChannelSync (): unknown;
 
   getMsgUniqueId (UniqueId: string): string;
 
-  isMsgMatched (...args: unknown[]): unknown;
+  isMsgMatched (matchInfo: unknown): unknown;
 
   getOnlineFileMsgs (peer: Peer): Promise<GeneralCallResult & {
     msgList: {
@@ -147,7 +147,7 @@ export interface NodeIKernelMsgService {
     }[];  // 一大坨，懒得写
   }>;
 
-  getAllOnlineFileMsgs (...args: unknown[]): unknown;
+  getAllOnlineFileMsgs (): unknown;
 
   getLatestDbMsgs (peer: Peer, cnt: number): Promise<GeneralCallResult & {
     msgList: RawMessage[];
@@ -171,7 +171,7 @@ export interface NodeIKernelMsgService {
   }>;
 
   // @deprecated
-  getMsgsWithMsgTimeAndClientSeqForC2C (...args: unknown[]): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
+  getMsgsWithMsgTimeAndClientSeqForC2C (peer: Peer, arg2: string, arg3: string, arg4: number, arg5: boolean, arg6: boolean, arg7: boolean): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
   getMsgsWithStatus (params: {
     peer: Peer;
@@ -186,6 +186,7 @@ export interface NodeIKernelMsgService {
   getMsgsBySeqRange (peer: Peer, startSeq: string, endSeq: string): Promise<GeneralCallResult & {
     msgList: RawMessage[];
   }>;
+
   // @deprecated
   getMsgsBySeqAndCount (peer: Peer, seq: string, count: number, desc: boolean, isReverseOrder: boolean): Promise<GeneralCallResult & {
     msgList: RawMessage[];
@@ -211,19 +212,19 @@ export interface NodeIKernelMsgService {
 
   getSourceOfReplyMsgByClientSeqAndTime (peer: Peer, clientSeq: string, time: string, replyMsgId: string): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
-  getMsgsByTypeFilter (peer: Peer, msgId: string, cnt: unknown, queryOrder: boolean, typeFilter: {
+  getMsgsByTypeFilter (peer: Peer, msgId: string, cnt: Array<unknown>, queryOrder: boolean, typeFilter: {
     type: number,
     subtype: Array<number>;
   }): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
-  getMsgsByTypeFilters (peer: Peer, msgId: string, cnt: unknown, queryOrder: boolean, typeFilters: Array<{
+  getMsgsByTypeFilters (peer: Peer, msgId: string, cnt: number, queryOrder: boolean, typeFilters: Array<{
     type: number,
     subtype: Array<number>;
   }>): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
-  getMsgWithAbstractByFilterParam (...args: unknown[]): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
+  getMsgWithAbstractByFilterParam (arg1: Peer, arg2: string, arg3: string, arg4: number, arg5: MsgTypeFilter): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
-  queryMsgsWithFilter (...args: unknown[]): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
+  queryMsgsWithFilter (msgId: string, msgTime: string, param: QueryMsgsParams): Promise<GeneralCallResult & { msgList: RawMessage[]; }>;
 
   // queryMsgsWithFilterVer2(MsgId: string, MsgTime: string, param: QueryMsgsParams): Promise<unknown>;
 
@@ -235,11 +236,11 @@ export interface NodeIKernelMsgService {
     msgList: RawMessage[];
   }>;
 
-  setMsgRichInfoFlag (...args: unknown[]): unknown;
+  setMsgRichInfoFlag (flag: boolean): void;
 
   queryPicOrVideoMsgs (msgId: string, msgTime: string, megSeq: string, param: QueryMsgsParams): Promise<unknown>;
 
-  queryPicOrVideoMsgsDesktop (...args: unknown[]): unknown;
+  queryPicOrVideoMsgsDesktop (msgId: string, msgTime: string, msgSeq: string, param: QueryMsgsParams): unknown;
 
   queryEmoticonMsgs (msgId: string, msgTime: string, msgSeq: string, Params: QueryMsgsParams): Promise<unknown>;
 
@@ -247,81 +248,81 @@ export interface NodeIKernelMsgService {
 
   queryMsgsAndAbstractsWithFilter (msgId: string, msgTime: string, megSeq: string, param: QueryMsgsParams): unknown;
 
-  setFocusOnGuild (...args: unknown[]): unknown;
+  setFocusOnGuild (arg: unknown): unknown;
 
-  setFocusSession (...args: unknown[]): unknown;
+  setFocusSession (arg: unknown): unknown;
 
-  enableFilterUnreadInfoNotify (...args: unknown[]): unknown;
+  enableFilterUnreadInfoNotify (arg: unknown): unknown;
 
-  enableFilterMsgAbstractNotify (...args: unknown[]): unknown;
+  enableFilterMsgAbstractNotify (arg: unknown): unknown;
 
-  onScenesChangeForSilenceMode (...args: unknown[]): unknown;
+  onScenesChangeForSilenceMode (arg: unknown): unknown;
 
-  getContactUnreadCnt (...args: unknown[]): unknown;
+  getContactUnreadCnt (peers: Peer[]): unknown;
 
-  getUnreadCntInfo (...args: unknown[]): unknown;
+  getUnreadCntInfo (arg: unknown): unknown;
 
-  getGuildUnreadCntInfo (...args: unknown[]): unknown;
+  getGuildUnreadCntInfo (arg: unknown): unknown;
 
-  getGuildUnreadCntTabInfo (...args: unknown[]): unknown;
+  getGuildUnreadCntTabInfo (arg: unknown): unknown;
 
-  getAllGuildUnreadCntInfo (...args: unknown[]): unknown;
+  getAllGuildUnreadCntInfo (arg: unknown): unknown;
 
-  getAllJoinGuildCnt (...args: unknown[]): unknown;
+  getAllJoinGuildCnt (arg: unknown): unknown;
 
-  getAllDirectSessionUnreadCntInfo (...args: unknown[]): unknown;
+  getAllDirectSessionUnreadCntInfo (arg: unknown): unknown;
 
-  getCategoryUnreadCntInfo (...args: unknown[]): unknown;
+  getCategoryUnreadCntInfo (arg: unknown): unknown;
 
-  getGuildFeedsUnreadCntInfo (...args: unknown[]): unknown;
+  getGuildFeedsUnreadCntInfo (arg: unknown): unknown;
 
-  setUnVisibleChannelCntInfo (...args: unknown[]): unknown;
+  setUnVisibleChannelCntInfo (arg: unknown): unknown;
 
-  setUnVisibleChannelTypeCntInfo (...args: unknown[]): unknown;
+  setUnVisibleChannelTypeCntInfo (arg: unknown): unknown;
 
-  setVisibleGuildCntInfo (...args: unknown[]): unknown;
+  setVisibleGuildCntInfo (arg: unknown): unknown;
 
   setMsgRead (peer: Peer): Promise<GeneralCallResult>;
 
   setAllC2CAndGroupMsgRead (): Promise<unknown>;
 
-  setGuildMsgRead (...args: unknown[]): unknown;
+  setGuildMsgRead (arg: unknown): unknown;
 
-  setAllGuildMsgRead (...args: unknown[]): unknown;
+  setAllGuildMsgRead (arg: unknown): unknown;
 
-  setMsgReadAndReport (...args: unknown[]): unknown;
+  setMsgReadAndReport (peer: Peer, msg: RawMessage): unknown;
 
-  setSpecificMsgReadAndReport (...args: unknown[]): unknown;
+  setSpecificMsgReadAndReport (arg1: Peer, arg2: string): unknown;
 
-  setLocalMsgRead (...args: unknown[]): unknown;
+  setLocalMsgRead (peer: Peer): unknown;
 
-  setGroupGuildMsgRead (...args: unknown[]): unknown;
+  setGroupGuildMsgRead (arg: unknown): unknown;
 
-  getGuildGroupTransData (...args: unknown[]): unknown;
+  getGuildGroupTransData (arg: unknown): unknown;
 
-  setGroupGuildBubbleRead (...args: unknown[]): unknown;
+  setGroupGuildBubbleRead (arg: unknown): unknown;
 
-  getGuildGroupBubble (...args: unknown[]): unknown;
+  getGuildGroupBubble (arg: unknown): unknown;
 
-  fetchGroupGuildUnread (...args: unknown[]): unknown;
+  fetchGroupGuildUnread (arg: unknown): unknown;
 
-  setGroupGuildFlag (...args: unknown[]): unknown;
+  setGroupGuildFlag (arg: unknown): unknown;
 
-  setGuildUDCFlag (...args: unknown[]): unknown;
+  setGuildUDCFlag (arg: unknown): unknown;
 
-  setGuildTabUserFlag (...args: unknown[]): unknown;
+  setGuildTabUserFlag (arg: unknown): unknown;
 
   setBuildMode (flag: number/* 0 1 3 */): unknown;
 
-  setConfigurationServiceData (...args: unknown[]): unknown;
+  setConfigurationServiceData (arg: unknown): unknown;
 
-  setMarkUnreadFlag (...args: unknown[]): unknown;
+  setMarkUnreadFlag (peer: Peer, unread: boolean): unknown;
 
-  getChannelEventFlow (...args: unknown[]): unknown;
+  getChannelEventFlow (arg: unknown): unknown;
 
-  getMsgEventFlow (...args: unknown[]): unknown;
+  getMsgEventFlow (arg: unknown): unknown;
 
-  getRichMediaFilePathForMobileQQSend (...args: unknown[]): unknown;
+  getRichMediaFilePathForMobileQQSend (arg: unknown): unknown;
 
   getRichMediaFilePathForGuild (arg: {
     md5HexStr: string,
@@ -334,15 +335,15 @@ export interface NodeIKernelMsgService {
     file_uuid: '';
   }): string;
 
-  assembleMobileQQRichMediaFilePath (...args: unknown[]): unknown;
+  assembleMobileQQRichMediaFilePath (arg: unknown): unknown;
 
   getFileThumbSavePathForSend (thumbSize: number, createNeed: boolean): string;
 
-  getFileThumbSavePath (...args: unknown[]): unknown;
+  getFileThumbSavePath (arg1: string, arg2: number, arg3: boolean): unknown;
 
   translatePtt2Text (msgId: string, peer: Peer, msgElement: MessageElement): unknown;
 
-  setPttPlayedState (...args: unknown[]): unknown;
+  setPttPlayedState (arg1: string, arg2: Peer, arg3: string): unknown;
 
   fetchFavEmojiList (str: string, num: number, backward: boolean, forceRefresh: boolean): Promise<GeneralCallResult & {
     emojiInfoList: Array<{
@@ -368,49 +369,49 @@ export interface NodeIKernelMsgService {
     }>;
   }>;
 
-  addFavEmoji (...args: unknown[]): unknown;
+  addFavEmoji (arg: unknown): unknown;
 
-  fetchMarketEmoticonList (...args: unknown[]): unknown;
+  fetchMarketEmoticonList (arg1: number, arg2: number): unknown;
 
-  fetchMarketEmoticonShowImage (...args: unknown[]): unknown;
+  fetchMarketEmoticonShowImage (arg: unknown): unknown;
 
-  fetchMarketEmoticonAioImage (...args: unknown[]): unknown;
+  fetchMarketEmoticonAioImage (arg: unknown): unknown;
 
-  fetchMarketEmotionJsonFile (...args: unknown[]): unknown;
+  fetchMarketEmotionJsonFile (arg: unknown): unknown;
 
-  getMarketEmoticonPath (...args: unknown[]): unknown;
+  getMarketEmoticonPath (arg1: number, arg2: Array<unknown>[], arg3: number): unknown;
 
-  getMarketEmoticonPathBySync (...args: unknown[]): unknown;
+  getMarketEmoticonPathBySync (arg1: number, arg2: Array<unknown>[], arg3: number): unknown;
 
-  fetchMarketEmoticonFaceImages (...args: unknown[]): unknown;
+  fetchMarketEmoticonFaceImages (arg: unknown): unknown;
 
-  fetchMarketEmoticonAuthDetail (...args: unknown[]): unknown;
+  fetchMarketEmoticonAuthDetail (arg: unknown): unknown;
 
-  getFavMarketEmoticonInfo (...args: unknown[]): unknown;
+  getFavMarketEmoticonInfo (tabId: number, emojiId: string): unknown;
 
-  addRecentUsedFace (...args: unknown[]): unknown;
+  addRecentUsedFace (arg: unknown): unknown;
 
-  getRecentUsedFaceList (...args: unknown[]): unknown;
+  getRecentUsedFaceList (arg: unknown): unknown;
 
-  getMarketEmoticonEncryptKeys (...args: unknown[]): unknown;
+  getMarketEmoticonEncryptKeys (arg1: number, arg2: Array<unknown>[]): unknown;
 
-  downloadEmojiPic (...args: unknown[]): unknown;
+  downloadEmojiPic (arg1: number, arg2: Array<unknown>[], arg3: number, arg4: Map<unknown, unknown>): unknown;
 
-  deleteFavEmoji (...args: unknown[]): unknown;
+  deleteFavEmoji (arg: unknown): unknown;
 
-  modifyFavEmojiDesc (...args: unknown[]): unknown;
+  modifyFavEmojiDesc (arg: unknown): unknown;
 
-  queryFavEmojiByDesc (...args: unknown[]): unknown;
+  queryFavEmojiByDesc (arg: unknown): unknown;
 
-  getHotPicInfoListSearchString (...args: unknown[]): unknown;
+  getHotPicInfoListSearchString (arg1: string, arg2: string, arg3: number, arg4: number, arg5: boolean): unknown;
 
-  getHotPicSearchResult (...args: unknown[]): unknown;
+  getHotPicSearchResult (arg: unknown): unknown;
 
-  getHotPicHotWords (...args: unknown[]): unknown;
+  getHotPicHotWords (arg: unknown): unknown;
 
-  getHotPicJumpInfo (...args: unknown[]): unknown;
+  getHotPicJumpInfo (arg: unknown): unknown;
 
-  getEmojiResourcePath (...args: unknown[]): unknown;
+  getEmojiResourcePath (arg: unknown): unknown;
 
   JoinDragonGroupEmoji (JoinDragonGroupEmojiReq: {
     latestMsgSeq: string,
@@ -419,17 +420,17 @@ export interface NodeIKernelMsgService {
     peerContact: Peer;
   }): Promise<unknown>;
 
-  getMsgAbstracts (...args: unknown[]): unknown;
+  getMsgAbstracts (arg: unknown): unknown;
 
-  getMsgAbstract (...args: unknown[]): unknown;
+  getMsgAbstract (arg1: Peer, arg2: string): unknown;
 
-  getMsgAbstractList (...args: unknown[]): unknown;
+  getMsgAbstractList (arg: unknown): unknown;
 
-  getMsgAbstractListBySeqRange (...args: unknown[]): unknown;
+  getMsgAbstractListBySeqRange (arg: unknown): unknown;
 
-  refreshMsgAbstracts (...args: unknown[]): unknown;
+  refreshMsgAbstracts (arg: unknown): unknown;
 
-  refreshMsgAbstractsByGuildIds (...args: unknown[]): unknown;
+  refreshMsgAbstractsByGuildIds (arg: unknown): unknown;
 
   getRichMediaElement (arg: {
     msgId: string,
@@ -440,7 +441,7 @@ export interface NodeIKernelMsgService {
     downloadType: number,
   }): Promise<any>;
 
-  cancelGetRichMediaElement (...args: unknown[]): unknown;
+  cancelGetRichMediaElement (arg: unknown): unknown;
 
   refuseGetRichMediaElement (args: {
     msgId: string,
@@ -451,7 +452,7 @@ export interface NodeIKernelMsgService {
     downSourceType: number, // 1
   }): Promise<void>;
 
-  switchToOfflineGetRichMediaElement (...args: unknown[]): unknown;
+  switchToOfflineGetRichMediaElement (arg: unknown): unknown;
 
   downloadRichMedia (args: {
     fileModelId: string,
@@ -473,21 +474,21 @@ export interface NodeIKernelMsgService {
     guildId: string;
   }): Promise<unknown>;
 
-  getFirstUnreadCommonMsg (...args: unknown[]): unknown;
+  getFirstUnreadCommonMsg (arg: unknown): unknown;
 
-  getFirstUnreadAtmeMsg (...args: unknown[]): unknown;
+  getFirstUnreadAtmeMsg (peer: Peer): unknown;
 
-  getFirstUnreadAtallMsg (...args: unknown[]): unknown;
+  getFirstUnreadAtallMsg (peer: Peer): unknown;
 
-  getNavigateInfo (...args: unknown[]): unknown;
+  getNavigateInfo (arg: unknown): unknown;
 
-  getChannelFreqLimitInfo (...args: unknown[]): unknown;
+  getChannelFreqLimitInfo (arg: unknown): unknown;
 
-  getRecentUseEmojiList (...args: unknown[]): unknown;
+  getRecentUseEmojiList (): unknown;
 
-  getRecentEmojiList (...args: unknown[]): unknown;
+  getRecentEmojiList (arg: unknown): unknown;
 
-  setMsgEmojiLikes (...args: unknown[]): unknown;
+  setMsgEmojiLikes (peer: Peer, msgSeq: string, emojiId: string, emojiType: string, setOrCancel: boolean): unknown;
 
   getMsgEmojiLikesList (peer: Peer, msgSeq: string, emojiId: string, emojiType: string, cookie: string, bForward: boolean, number: number): Promise<{
     result: number,
@@ -503,7 +504,7 @@ export interface NodeIKernelMsgService {
     isFirstPage: boolean;
   }>;
 
-  setMsgEmojiLikesForRole (...args: unknown[]): unknown;
+  setMsgEmojiLikesForRole (arg1: Peer, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, arg7: boolean, arg8: boolean, arg9: SgrpStreamParams): unknown;
 
   clickInlineKeyboardButton (params: {
     guildId?: string,
@@ -516,7 +517,7 @@ export interface NodeIKernelMsgService {
     chatType: number; // 1私聊 2群
   }): Promise<GeneralCallResult & { status: number, promptText: string, promptType: number, promptIcon: number; }>;
 
-  setCurOnScreenMsg (...args: unknown[]): unknown;
+  setCurOnScreenMsg (arg: unknown): unknown;
 
   setCurOnScreenMsgForMsgEvent (peer: Peer, msgRegList: Map<string, Uint8Array>): void;
 
@@ -524,91 +525,91 @@ export interface NodeIKernelMsgService {
 
   setMiscData (key: string, value: string): unknown;
 
-  getBookmarkData (...args: unknown[]): unknown;
+  getBookmarkData (key: string): unknown;
 
-  setBookmarkData (...args: unknown[]): unknown;
+  setBookmarkData (key: string, value: string): unknown;
 
   sendShowInputStatusReq (ChatType: number, EventType: number, toUid: string): Promise<unknown>;
 
-  queryCalendar (...args: unknown[]): unknown;
+  queryCalendar (peer: Peer, msgTime: number): unknown;
 
-  queryFirstMsgSeq (peer: Peer, ...args: unknown[]): unknown;
+  queryFirstMsgSeq (peer: Peer, msgTime: number): unknown;
 
-  queryRoamCalendar (...args: unknown[]): unknown;
+  queryRoamCalendar (peer: Peer, msgTime: number): unknown;
 
-  queryFirstRoamMsg (...args: unknown[]): unknown;
+  queryFirstRoamMsg (peer: Peer, msgTime: number): unknown;
 
   fetchLongMsg (peer: Peer, msgId: string): unknown;
 
-  fetchLongMsgWithCb (...args: unknown[]): unknown;
+  fetchLongMsgWithCb (peer: Peer, msgId: number): unknown;
 
-  setIsStopKernelFetchLongMsg (...args: unknown[]): unknown;
+  setIsStopKernelFetchLongMsg (arg: unknown): unknown;
 
-  insertGameResultAsMsgToDb (...args: unknown[]): unknown;
+  insertGameResultAsMsgToDb (arg: unknown): unknown;
 
-  getMultiMsg (...args: unknown[]): Promise<GeneralCallResult & {
+  getMultiMsg (arg1: Peer, arg2: string, arg3: string): Promise<GeneralCallResult & {
     msgList: RawMessage[];
   }>;
 
-  setDraft (...args: unknown[]): unknown;
+  setDraft (arg1: Peer, arg2: Array<unknown>[]): unknown;
 
-  getDraft (...args: unknown[]): unknown;
+  getDraft (peer: Peer): unknown;
 
-  deleteDraft (...args: unknown[]): unknown;
+  deleteDraft (peer: Peer): unknown;
 
-  getRecentHiddenSesionList (...args: unknown[]): unknown;
+  getRecentHiddenSesionList (): unknown;
 
-  setRecentHiddenSession (...args: unknown[]): unknown;
+  setRecentHiddenSession (arg: unknown): unknown;
 
-  delRecentHiddenSession (...args: unknown[]): unknown;
+  delRecentHiddenSession (arg: unknown): unknown;
 
-  getCurHiddenSession (...args: unknown[]): unknown;
+  getCurHiddenSession (): unknown;
 
-  setCurHiddenSession (...args: unknown[]): unknown;
+  setCurHiddenSession (arg: unknown): unknown;
 
-  setReplyDraft (...args: unknown[]): unknown;
+  setReplyDraft (arg1: Peer, arg2: string, arg3: Array<unknown>[]): unknown;
 
-  getReplyDraft (...args: unknown[]): unknown;
+  getReplyDraft (arg1: Peer, arg2: string): unknown;
 
-  deleteReplyDraft (...args: unknown[]): unknown;
+  deleteReplyDraft (arg1: Peer, arg2: string): unknown;
 
   getFirstUnreadAtMsg (peer: Peer): unknown;
 
-  clearMsgRecords (...args: unknown[]): unknown;
+  clearMsgRecords (peer: Peer): unknown;
 
-  IsExistOldDb (...args: unknown[]): unknown;
+  IsExistOldDb (): unknown;
 
-  canImportOldDbMsg (...args: unknown[]): unknown;
+  canImportOldDbMsg (): unknown;
 
   setPowerStatus (isPowerOn: boolean): unknown;
 
-  canProcessDataMigration (...args: unknown[]): unknown;
+  canProcessDataMigration (): unknown;
 
-  importOldDbMsg (...args: unknown[]): unknown;
+  importOldDbMsg (): unknown;
 
-  stopImportOldDbMsgAndroid (...args: unknown[]): unknown;
+  stopImportOldDbMsgAndroid (): unknown;
 
-  isMqqDataImportFinished (...args: unknown[]): unknown;
+  isMqqDataImportFinished (): unknown;
 
-  getMqqDataImportTableNames (...args: unknown[]): unknown;
+  getMqqDataImportTableNames (): unknown;
 
-  getCurChatImportStatusByUin (...args: unknown[]): unknown;
+  getCurChatImportStatusByUin (arg1: unknown, arg2: unknown): unknown;
 
   getDataImportUserLevel (): unknown;
 
-  getMsgQRCode (...args: unknown[]): unknown;
+  getMsgQRCode (): unknown;
 
-  getGuestMsgAbstracts (...args: unknown[]): unknown;
+  getGuestMsgAbstracts (arg: unknown): unknown;
 
-  getGuestMsgByRange (...args: unknown[]): unknown;
+  getGuestMsgByRange (arg: unknown): unknown;
 
-  getGuestMsgAbstractByRange (...args: unknown[]): unknown;
+  getGuestMsgAbstractByRange (arg: unknown): unknown;
 
-  registerSysMsgNotification (...args: unknown[]): unknown;
+  registerSysMsgNotification (arg1: number, arg2: string, arg3: Array<unknown>[]): unknown;
 
-  unregisterSysMsgNotification (...args: unknown[]): unknown;
+  unregisterSysMsgNotification (arg1: number, arg2: string, arg3: Array<unknown>[]): unknown;
 
-  enterOrExitAio (...args: unknown[]): unknown;
+  enterOrExitAio (arg: unknown): unknown;
 
   prepareTempChat (args: unknown): unknown;
 
@@ -616,66 +617,66 @@ export interface NodeIKernelMsgService {
 
   getTempChatInfo (ChatType: number, Uid: string): Promise<TmpChatInfoApi>;
 
-  setContactLocalTop (...args: unknown[]): unknown;
+  setContactLocalTop (peer: Peer, isTop: boolean): unknown;
 
-  switchAnonymousChat (...args: unknown[]): unknown;
+  switchAnonymousChat (arg1: string, arg2: boolean): unknown;
 
-  renameAnonyChatNick (...args: unknown[]): unknown;
+  renameAnonyChatNick (arg: unknown): unknown;
 
-  getAnonymousInfo (...args: unknown[]): unknown;
+  getAnonymousInfo (peer: Peer): unknown;
 
-  updateAnonymousInfo (...args: unknown[]): unknown;
+  updateAnonymousInfo (peer: Peer, arg2: unknown): unknown;
 
   sendSummonMsg (peer: Peer, MsgElement: unknown, MsgAttributeInfo: unknown): Promise<unknown>;// 频道的东西
 
-  outputGuildUnreadInfo (...args: unknown[]): unknown;
+  outputGuildUnreadInfo (arg: unknown): unknown;
 
-  checkMsgWithUrl (...args: unknown[]): unknown;
+  checkMsgWithUrl (arg: unknown): unknown;
 
-  checkTabListStatus (...args: unknown[]): unknown;
+  checkTabListStatus (): unknown;
 
-  getABatchOfContactMsgBoxInfo (...args: unknown[]): unknown;
+  getABatchOfContactMsgBoxInfo (arg: unknown): unknown;
 
   insertMsgToMsgBox (peer: Peer, msgId: string, arg: 2006): unknown;
 
-  isHitEmojiKeyword (...args: unknown[]): unknown;
+  isHitEmojiKeyword (arg: unknown): unknown;
 
-  getKeyWordRelatedEmoji (...args: unknown[]): unknown;
+  getKeyWordRelatedEmoji (arg: unknown): unknown;
 
-  recordEmoji (...args: unknown[]): unknown;
+  recordEmoji (type: number, emojiList: Array<unknown>): unknown;
 
   fetchGetHitEmotionsByWord (args: unknown): Promise<unknown>;// 表情推荐？
 
-  deleteAllRoamMsgs (...args: unknown[]): unknown;// 漫游消息？
+  deleteAllRoamMsgs (arg1: number, arg2: string): unknown;// 漫游消息？
 
-  packRedBag (...args: unknown[]): unknown;
+  packRedBag (arg: unknown): unknown;
 
-  grabRedBag (...args: unknown[]): unknown;
+  grabRedBag (arg: unknown): unknown;
 
-  pullDetail (...args: unknown[]): unknown;
+  pullDetail (arg: unknown): unknown;
 
-  selectPasswordRedBag (...args: unknown[]): unknown;
+  selectPasswordRedBag (arg: unknown): unknown;
 
-  pullRedBagPasswordList (...args: unknown[]): unknown;
+  pullRedBagPasswordList (): unknown;
 
-  requestTianshuAdv (...args: unknown[]): unknown;
+  requestTianshuAdv (arg: unknown): unknown;
 
-  tianshuReport (...args: unknown[]): unknown;
+  tianshuReport (arg: unknown): unknown;
 
-  tianshuMultiReport (...args: unknown[]): unknown;
+  tianshuMultiReport (arg: unknown): unknown;
 
   GetMsgSubType (a0: number, a1: number): unknown;
 
-  setIKernelPublicAccountAdapter (...args: unknown[]): unknown;
+  setIKernelPublicAccountAdapter (arg: unknown): unknown;
 
   // tempChatGameSession有关
   createUidFromTinyId (fromTinyId: string, toTinyId: string): string;
 
-  dataMigrationGetDataAvaiableContactList (...args: unknown[]): unknown;
+  dataMigrationGetDataAvaiableContactList (): unknown;
 
-  dataMigrationGetMsgList (...args: unknown[]): unknown;
+  dataMigrationGetMsgList (arg1: unknown, arg2: unknown): unknown;
 
-  dataMigrationStopOperation (...args: unknown[]): unknown;
+  dataMigrationStopOperation (arg: unknown): unknown;
 
   dataMigrationImportMsgPbRecord (DataMigrationMsgInfo: Array<{
     extensionData: string;// "Hex"
@@ -696,38 +697,37 @@ export interface NodeIKernelMsgService {
     msgType: number;
   }): unknown;
 
-  dataMigrationGetResourceLocalDestinyPath (...args: unknown[]): unknown;
+  dataMigrationGetResourceLocalDestinyPath (arg: unknown): unknown;
 
-  dataMigrationSetIOSPathPrefix (...args: unknown[]): unknown;
+  dataMigrationSetIOSPathPrefix (arg: unknown): unknown;
 
-  getServiceAssistantSwitch (...args: unknown[]): unknown;
+  getServiceAssistantSwitch (arg: unknown): unknown;
 
-  setServiceAssistantSwitch (...args: unknown[]): unknown;
+  setServiceAssistantSwitch (arg: unknown): unknown;
 
-  setSubscribeFolderUsingSmallRedPoint (...args: unknown[]): unknown;
+  setSubscribeFolderUsingSmallRedPoint (arg: unknown): unknown;
 
-  clearGuildNoticeRedPoint (...args: unknown[]): unknown;
+  clearGuildNoticeRedPoint (arg: unknown): unknown;
 
-  clearFeedNoticeRedPoint (...args: unknown[]): unknown;
+  clearFeedNoticeRedPoint (arg: unknown): unknown;
 
-  clearFeedSquareRead (...args: unknown[]): unknown;
+  clearFeedSquareRead (arg: unknown): unknown;
 
-  IsC2CStyleChatType (...args: unknown[]): unknown;
+  IsC2CStyleChatType (chatType: unknown): unknown;
 
   IsTempChatType (uin: number): unknown;// 猜的
 
-  getGuildInteractiveNotification (...args: unknown[]): unknown;
+  getGuildInteractiveNotification (arg: unknown): unknown;
 
-  getGuildNotificationAbstract (...args: unknown[]): unknown;
+  getGuildNotificationAbstract (arg: unknown): unknown;
 
-  setFocusOnBase (...args: unknown[]): unknown;
+  setFocusOnBase (arg: unknown): unknown;
 
-  queryArkInfo (...args: unknown[]): unknown;
+  queryArkInfo (arg: unknown): unknown;
 
-  queryUserSecQuality (...args: unknown[]): unknown;
+  queryUserSecQuality (): unknown;
 
-  getGuildMsgAbFlag (...args: unknown[]): unknown;
+  getGuildMsgAbFlag (arg: unknown): unknown;
 
   getGroupMsgStorageTime (): unknown;
-
 }

--- a/packages/napcat-core/services/NodeIKernelNearbyProService.ts
+++ b/packages/napcat-core/services/NodeIKernelNearbyProService.ts
@@ -1,0 +1,11 @@
+export interface NodeIKernelNearbyProService {
+  addKernelNearbyProListener (listener: unknown): number;
+
+  removeKernelNearbyProListener (listenerId: number): void;
+
+  fetchNearbyProUserInfo (arg1: unknown[], arg2: unknown, arg3: boolean): unknown;
+
+  setCommonExtInfo (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelNodeMiscService.ts
+++ b/packages/napcat-core/services/NodeIKernelNodeMiscService.ts
@@ -14,4 +14,118 @@ export interface NodeIKernelNodeMiscService {
   startNewMiniApp (appfile: string, params: string): unknown;
 
   getQimei36WithNewSdk (): Promise<string>;
+
+  adaptMiniAppShareInfo (arg: unknown): unknown;
+
+  addBind (arg1: unknown, arg2: unknown): unknown;
+
+  changeSendKey (arg: unknown): unknown;
+
+  checkIfHaveAvailableSidecarDevice (arg: unknown): unknown;
+
+  clearQzoneUnreadCount (arg: unknown): unknown;
+
+  clearQzoneUnreadCountWithRedDot (arg: unknown): unknown;
+
+  closeWXMiniApp (arg: unknown): unknown;
+
+  delBind (arg: unknown): unknown;
+
+  deleteShareFile (arg: unknown): unknown;
+
+  dispatchWmpfEvent (arg: unknown): unknown;
+
+  doAction (arg1: unknown, arg2: unknown): unknown;
+
+  doPostAction (arg1: unknown, arg2: unknown): unknown;
+
+  downloadMiniApp (arg: unknown): unknown;
+
+  downloadMiniGame (arg: unknown): unknown;
+
+  encodeAES (arg1: unknown, arg2: unknown): unknown;
+
+  flashWindowInTaskbar (arg1: unknown, arg2: unknown): unknown;
+
+  getAppLaunchInfo (arg: unknown): unknown;
+
+  getCurWindowInfo (arg: unknown): unknown;
+
+  getCurWindowInfoExceptList (arg: unknown): unknown;
+
+  getMiniGameV2EngineConfig (arg: unknown): unknown;
+
+  getMyAppList (arg: unknown): unknown;
+
+  getOpenAuth (arg1: unknown, arg2: unknown): unknown;
+
+  getQQlevelInfo (arg: unknown): unknown;
+
+  getQzoneUnreadCount (arg: unknown): unknown;
+
+  installApp (arg1: unknown, arg2: unknown): unknown;
+
+  isAppInstalled (arg: unknown): unknown;
+
+  isOldQQRunning (arg: unknown): unknown;
+
+  judgeTimingRequest (arg: unknown): unknown;
+
+  listenWindowEvents (arg: unknown): unknown;
+
+  loginWXMiniApp (arg: unknown): unknown;
+
+  openFileAndDirSelectDlg (arg: unknown): unknown;
+
+  prefetch (arg: unknown): unknown;
+
+  qqConnectBatchShare (arg1: unknown, arg2: unknown): unknown;
+
+  qqConnectShare (arg: unknown): unknown;
+
+  qqConnectShareCheck (arg: unknown): unknown;
+
+  registerSchemes (arg: unknown): unknown;
+
+  registerScreenCaptureShortcutWithKeycode (arg: unknown): unknown;
+
+  registerScreenRecordShortcutWithKeycode (arg: unknown): unknown;
+
+  removeQuarantineAttribute (arg: unknown): unknown;
+
+  reportExecuteRequest (arg: unknown): unknown;
+
+  scanQBar (arg: unknown): unknown;
+
+  sendMessageResponseToWX (arg1: unknown, arg2: unknown): unknown;
+
+  sendRequestToApiGateway (arg: unknown): unknown;
+
+  sendWXCustomMenuClickedAction (arg1: unknown, arg2: unknown): unknown;
+
+  setBackgroudWindowLevel (arg1: unknown, arg2: unknown): unknown;
+
+  setMiniGameVersion (arg: unknown): unknown;
+
+  setVulkanEnable (arg: unknown): unknown;
+
+  setWindowLevelNT (arg1: unknown, arg2: unknown): unknown;
+
+  setWindowsMenuInstallStatus (arg: unknown): unknown;
+
+  setWXCustomMenuConfig (arg1: unknown, arg2: unknown): unknown;
+
+  startNewApp (arg: unknown): unknown;
+
+  startScreenCapture (arg1: unknown, arg2: unknown): unknown;
+
+  stopFlashWindow (arg: unknown): unknown;
+
+  unlistenWindowEvents (arg: unknown): unknown;
+
+  unregisterHotkey (arg: unknown): unknown;
+
+  writeBitmapToClipboard (arg: unknown): unknown;
+
+  writeClipboard (arg1: unknown, arg2: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelOnlineStatusService.ts
+++ b/packages/napcat-core/services/NodeIKernelOnlineStatusService.ts
@@ -1,36 +1,29 @@
 export interface NodeIKernelOnlineStatusService {
 
-  addKernelOnlineStatusListener(listener: unknown): number;
+  addKernelOnlineStatusListener (listener: unknown): number;
 
-  removeKernelOnlineStatusListener(listenerId: number): void;
+  removeKernelOnlineStatusListener (listenerId: number): void;
 
-  getShouldShowAIOStatusAnimation(arg: unknown): unknown;
+  getShouldShowAIOStatusAnimation (arg: unknown): unknown;
 
-  setReadLikeList(arg: unknown): unknown;
+  setReadLikeList (arg: unknown): unknown;
 
-  getLikeList(arg: unknown): unknown;
+  getLikeList (arg: unknown): Promise<unknown>;
 
-  setLikeStatus(arg: unknown): unknown;
+  setLikeStatus (arg: unknown): Promise<unknown>;
 
-  getAggregationPageEntrance(): unknown;
+  setOnlineStatusLiteBusinessSwitch (enabled: boolean): void;
 
-  didClickAggregationPageEntrance(): unknown;
+  getAggregationPageEntrance (): unknown;
 
-  getAggregationGroupModels(): unknown;
+  didClickAggregationPageEntrance (): unknown;
 
-  // {
-  //   "businessType": 1,
-  //   "uins": [
-  //     "1627126029",
-  //     "66600000",
-  //     "71702575"
-  //   ]
-  // }
+  getAggregationGroupModels (): unknown;
 
-  checkLikeStatus(param: {
+  checkLikeStatus (param: {
     businessType: number,
-    uins: string[]
+    uins: string[];
   }): Promise<unknown>;
 
-  isNull(): boolean;
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelPersonalAlbumService.ts
+++ b/packages/napcat-core/services/NodeIKernelPersonalAlbumService.ts
@@ -1,0 +1,75 @@
+export interface NodeIKernelPersonalAlbumService {
+  addAlbumPermissions (arg: unknown): unknown;
+
+  addComment (arg: unknown): unknown;
+
+  addReply (arg: unknown): unknown;
+
+  createAlbum (arg: unknown): unknown;
+
+  delBatchPhoto (arg: unknown): unknown;
+
+  deleteAlbum (arg: unknown): unknown;
+
+  deleteComment (arg: unknown): unknown;
+
+  deleteReply (arg: unknown): unknown;
+
+  doLike (arg: unknown): unknown;
+
+  editAlbum (arg: unknown): unknown;
+
+  editTravelAlbumScence (arg: unknown): unknown;
+
+  forwardAlbumToQzone (arg: unknown): unknown;
+
+  getAlbumInviteJoinPage (arg: unknown): unknown;
+
+  getAlbumJoinApprovalPage (arg: unknown): unknown;
+
+  getAlbumList (arg: unknown): unknown;
+
+  getAlbumMemberList (arg: unknown): unknown;
+
+  getCommentList (arg: unknown): unknown;
+
+  getLayerTailpageRecommend (arg: unknown): unknown;
+
+  getPhotoList (arg: unknown): unknown;
+
+  getPhotoListByTimeLine (arg: unknown): unknown;
+
+  getPhotoTabByTimeLine (arg: unknown): unknown;
+
+  getShareInfo (arg: unknown): unknown;
+
+  getVideoTabByTimeLine (arg: unknown): unknown;
+
+  inviteCheckForLoversAlbum (arg: unknown): unknown;
+
+  joinShareAlbum (arg: unknown): unknown;
+
+  moveBatchPhoto (arg: unknown): unknown;
+
+  queryAlbum (arg: unknown): unknown;
+
+  quitSharedAlbum (arg: unknown): unknown;
+
+  removeAlbumMember (arg: unknown): unknown;
+
+  respondToJoinRequest (arg: unknown): unknown;
+
+  sendAlbumInvitation (arg: unknown): unknown;
+
+  setAlbumServiceInfo (arg1: string, arg2: string, arg3: string): unknown;
+
+  setTopAlbum (arg: unknown): unknown;
+
+  unLike (arg: unknown): unknown;
+
+  updateAlbumMember (arg: unknown): unknown;
+
+  verifyAlbumQuestion (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelProfileLikeService.ts
+++ b/packages/napcat-core/services/NodeIKernelProfileLikeService.ts
@@ -1,37 +1,37 @@
 import { BuddyProfileLikeReq, GeneralCallResult, NTVoteInfo } from '@/napcat-core/index';
 
 export interface NodeIKernelProfileLikeService {
-  addKernelProfileLikeListener(listener: unknown): number;
+  addKernelProfileLikeListener (listener: unknown): number;
 
-  removeKernelProfileLikeListener(listenerId: unknown): void;
+  removeKernelProfileLikeListener (listenerId: number): void;
 
-  setBuddyProfileLike(...args: unknown[]): { result: number, errMsg: string, succCounts: number };
+  setBuddyProfileLike (arg: unknown): Promise<{ result: number, errMsg: string, succCounts: number; }>;
 
-  getBuddyProfileLike(req: BuddyProfileLikeReq): Promise<GeneralCallResult & {
+  getBuddyProfileLike (req: BuddyProfileLikeReq): Promise<GeneralCallResult & {
     info: {
       userLikeInfos: Array<{
         uid: string,
         time: string,
         favoriteInfo: {
-          userInfos: Array<NTVoteInfo>, // 哪些人点我
+          userInfos: Array<NTVoteInfo>,
           total_count: number,
           last_time: number,
-          today_count: number
+          today_count: number;
         },
         voteInfo: {
           total_count: number,
           new_count: number,
           new_nearby_count: number,
           last_visit_time: number,
-          userInfos: Array<NTVoteInfo>, // 点过哪些人
-        }
+          userInfos: Array<NTVoteInfo>;
+        };
       }>,
       friendMaxVotes: number,
-      start: number
-    }
+      start: number;
+    };
   }>;
 
-  getProfileLikeScidResourceInfo(...args: unknown[]): void;
+  getProfileLikeScidResourceInfo (arg: unknown): void;
 
-  isNull(): boolean;
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelProfileService.ts
+++ b/packages/napcat-core/services/NodeIKernelProfileService.ts
@@ -3,80 +3,94 @@ import { BizKey, ModifyProfileParams, NodeIKernelProfileListener, ProfileBizType
 import { GeneralCallResult } from '@/napcat-core/services/common';
 
 export interface NodeIKernelProfileService {
-  getOtherFlag(callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
+  getOtherFlag (callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
 
-  getVasInfo(callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
+  getVasInfo (callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
 
-  getRelationFlag(callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
+  getRelationFlag (callfrom: string, uids: string[]): Promise<Map<string, unknown>>;
 
-  getUidByUin(callfrom: string, uin: Array<string>): Map<string, string>;
+  getUidByUin (callfrom: string, uin: Array<string>): Map<string, string>;
 
-  getUinByUid(callfrom: string, uid: Array<string>): Map<string, string>;
+  getUinByUid (callfrom: string, uid: Array<string>): Map<string, string>;
 
-  getCoreAndBaseInfo(callfrom: string, uids: string[]): Promise<Map<string, SimpleInfo>>;
+  getCoreAndBaseInfo (callfrom: string, uids: string[]): Promise<Map<string, SimpleInfo>>;
 
-  fetchUserDetailInfo(trace: string, uids: string[], source: UserDetailSource, bizType: ProfileBizType[]): Promise<GeneralCallResult &
-    {
-      source: UserDetailSource,
-      // uid -> detail
-      detail: Map<string, UserDetailInfoListenerArg>,
-    }
-    >;
+  fetchUserDetailInfo (trace: string, uids: string[], source: UserDetailSource, bizType: ProfileBizType[]): Promise<GeneralCallResult &
+  {
+    source: UserDetailSource,
+    // uid -> detail
+    detail: Map<string, UserDetailInfoListenerArg>,
+  }
+  >;
 
-  addKernelProfileListener(listener: NodeIKernelProfileListener): number;
+  addKernelProfileListener (listener: NodeIKernelProfileListener): number;
 
-  removeKernelProfileListener(listenerId: number): void;
+  removeKernelProfileListener (listenerId: number): void;
 
-  prepareRegionConfig(...args: unknown[]): unknown;
+  prepareRegionConfig (): unknown;
 
-  getLocalStrangerRemark(): Promise<AnyCnameRecord>;
+  getLocalStrangerRemark (): Promise<AnyCnameRecord>;
 
-  enumCountryOptions(): Array<string>;
+  enumCountryOptions (): Array<string>;
 
-  enumProvinceOptions(country: string): Array<string>;
+  enumProvinceOptions (country: string): Array<string>;
 
-  enumCityOptions(country: string, province: string): unknown;
+  enumCityOptions (country: string, province: string): unknown;
 
-  enumAreaOptions(...args: unknown[]): unknown;
+  enumAreaOptions (arg1: string, arg2: string, arg3: string): unknown;
 
-  modifySelfProfile(...args: unknown[]): Promise<unknown>;
+  modifySelfProfile (param: unknown): Promise<unknown>;
 
-  modifyDesktopMiniProfile(param: ModifyProfileParams): Promise<GeneralCallResult>;
+  modifyDesktopMiniProfile (param: ModifyProfileParams): Promise<GeneralCallResult>;
 
-  setNickName(nickName: string): Promise<unknown>;
+  setNickName (nickName: string): Promise<unknown>;
 
-  setLongNick(longNick: string): Promise<unknown>;
+  setLongNick (longNick: string): Promise<unknown>;
 
-  setBirthday(...args: unknown[]): Promise<unknown>;
+  setBirthday (year: number, month: number, day: number): Promise<unknown>;
 
-  setGander(...args: unknown[]): Promise<unknown>;
+  setGander (gender: unknown): Promise<unknown>;
 
-  setHeader(arg: string): Promise<GeneralCallResult>;
+  setHeader (arg: string): Promise<GeneralCallResult>;
 
-  setRecommendImgFlag(...args: unknown[]): Promise<unknown>;
+  setRecommendImgFlag (flag: unknown): Promise<unknown>;
 
-  getUserSimpleInfo(force: boolean, uids: string[]): Promise<unknown>;
+  getUserSimpleInfo (force: boolean, uids: string[]): Promise<unknown>;
 
-  getUserDetailInfo(uid: string): Promise<unknown>;
+  getUserDetailInfo (uid: string): Promise<unknown>;
 
-  getUserDetailInfoWithBizInfo(uid: string, Biz: BizKey[]): Promise<GeneralCallResult>;
+  getUserDetailInfoWithBizInfo (uid: string, Biz: BizKey[]): Promise<GeneralCallResult>;
 
-  getUserDetailInfoByUin(uin: string): Promise<UserDetailInfoByUin>;
+  getUserDetailInfoByUin (uin: string): Promise<UserDetailInfoByUin>;
 
-  getZplanAvatarInfos(args: string[]): Promise<unknown>;
+  getZplanAvatarInfos (args: string[]): Promise<unknown>;
 
-  getStatus(uid: string): Promise<unknown>;
+  getStatus (uid: string): Promise<unknown>;
 
-  startStatusPolling(isForceReset: boolean): Promise<unknown>;
+  startStatusPolling (isForceReset: boolean): Promise<unknown>;
 
-  getSelfStatus(): Promise<unknown>;
+  getSelfStatus (): Promise<unknown>;
 
-  setdisableEmojiShortCuts(...args: unknown[]): unknown;
+  setdisableEmojiShortCuts (arg: unknown): unknown;
 
-  getProfileQzonePicInfo(uid: string, type: number, force: boolean): Promise<unknown>;
+  getProfileQzonePicInfo (uid: string, type: number, force: boolean): Promise<unknown>;
 
   // UserRemarkServiceImpl::getStrangerRemarkByUid []
-  getCoreInfo(sceneId: string, arg: unknown[]): unknown;
+  getCoreInfo (sceneId: string, arg: unknown[]): unknown;
 
-  isNull(): boolean;
+  isNull (): boolean;
+
+  addKernelProfileListenerForUICache (listener: unknown): number;
+
+  asyncGetCoreInfo (callfrom: string, uids: string[]): unknown;
+
+  getIntimate (uid: string, arg: unknown): unknown;
+
+  getStatusInfo (uid: string, arg: unknown): unknown;
+
+  getStockLocalData (key: string, arg: unknown): unknown;
+
+  updateProfileData (uid: string, data: unknown): unknown;
+
+  updateStockLocalData (key: string, data: unknown): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelPublicAccountService.ts
+++ b/packages/napcat-core/services/NodeIKernelPublicAccountService.ts
@@ -1,0 +1,15 @@
+export interface NodeIKernelPublicAccountService {
+  addListener (listener: unknown): number;
+
+  removeListener (listenerId: number): void;
+
+  follow (arg: unknown): unknown;
+
+  queryTemplateInfo (arg: unknown): unknown;
+
+  subscribeTemplate (arg: unknown): unknown;
+
+  unfollow (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelQQPlayService.ts
+++ b/packages/napcat-core/services/NodeIKernelQQPlayService.ts
@@ -1,0 +1,19 @@
+export interface NodeIKernelQQPlayService {
+  addKernelQQPlayListener (listener: unknown): number;
+
+  removeKernelQQPlayListener (listenerId: number): void;
+
+  createLnkShortcut (arg1: string, arg2: string, arg3: string, arg4: string): unknown;
+
+  getSystemRegValue (arg1: number, arg2: string, arg3: string): unknown;
+
+  setSystemRegValue (arg1: number, arg2: string, arg3: string, arg4: string): unknown;
+
+  sendMsg2Simulator (arg1: unknown, arg2: unknown): unknown;
+
+  setForegroundWindow (arg: unknown): unknown;
+
+  startSimulator (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelQiDianService.ts
+++ b/packages/napcat-core/services/NodeIKernelQiDianService.ts
@@ -1,0 +1,21 @@
+export interface NodeIKernelQiDianService {
+  addKernelQiDianListener (listener: unknown): number;
+
+  removeKernelQiDianListener (listenerId: number): void;
+
+  requestExtUinForRemoteControl (arg1: string, arg2: string, arg3: number): unknown;
+
+  requestMainUinForRemoteControl (arg: unknown): unknown;
+
+  requestNaviConfig (arg: unknown): unknown;
+
+  requestQidianUidFromUin (arg: unknown): unknown;
+
+  requestWpaCorpInfo (arg: unknown): unknown;
+
+  requestWpaSigT (arg1: unknown, arg2: unknown): unknown;
+
+  requestWpaUserInfo (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelRDeliveryService.ts
+++ b/packages/napcat-core/services/NodeIKernelRDeliveryService.ts
@@ -1,0 +1,13 @@
+export interface NodeIKernelRDeliveryService {
+  addDataChangeListener (listener: unknown): number;
+
+  removeDataChangeListener (listenerId: number): void;
+
+  getRDeliveryDataByKey (arg: unknown): unknown;
+
+  requestBatchRemoteDataByScene (arg1: unknown, arg2: unknown): unknown;
+
+  requestSingleRemoteDataByKey (arg1: string, arg2: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelRecentContactService.ts
+++ b/packages/napcat-core/services/NodeIKernelRecentContactService.ts
@@ -4,17 +4,19 @@ import { GeneralCallResult } from '@/napcat-core/services/common';
 import { FSABRecentContactParams } from '@/napcat-core/types/contact';
 
 export interface NodeIKernelRecentContactService {
-  setGuildDisplayStatus(...args: unknown[]): unknown; // 2 arguments
+  setGuildDisplayStatus (arg1: unknown, arg2: unknown): unknown;
 
-  setContactListTop(...args: unknown[]): unknown; // 2 arguments
+  setContactListTop (peer: Peer, isTop: boolean): unknown;
 
-  updateRecentContactExtBufForUI(...args: unknown[]): unknown; // 2 arguments
+  updateRecentContactExtBufForUI (peer: Peer, extBuf: unknown): unknown;
 
-  upsertRecentContactManually(...args: unknown[]): unknown; // 1 arguments
+  upsertRecentContactManually (arg: unknown): unknown;
 
-  enterOrExitMsgList(...args: unknown[]): unknown; // 1 arguments
+  manageContactMergeWindow (arg: unknown): unknown;
 
-  getRecentContactListSnapShot(count: number): Promise<GeneralCallResult & {
+  enterOrExitMsgList (arg: unknown): unknown;
+
+  getRecentContactListSnapShot (count: number): Promise<GeneralCallResult & {
     info: {
       errCode: number,
       errMsg: string,
@@ -28,56 +30,56 @@ export interface NodeIKernelRecentContactService {
         peerUin: string,
         msgTime: string,
         chatType: ChatType,
-        msgId: string
-      }>
-    }
-  }>; // 1 arguments
+        msgId: string;
+      }>;
+    };
+  }>;
 
-  clearMsgUnreadCount(...args: unknown[]): unknown; // 1 arguments
+  clearMsgUnreadCount (peer: Peer): unknown;
 
-  getRecentContactListSyncLimit(count: number): unknown;
+  getRecentContactListSyncLimit (count: number): unknown;
 
-  jumpToSpecifyRecentContact(...args: unknown[]): unknown; // 1 arguments
+  jumpToSpecifyRecentContact (arg: unknown): unknown;
 
-  fetchAndSubscribeABatchOfRecentContact(params: FSABRecentContactParams): unknown; // 1 arguments
+  fetchAndSubscribeABatchOfRecentContact (params: FSABRecentContactParams): unknown;
 
-  addRecentContact(peer: Peer): unknown;
+  addRecentContact (peer: Peer): unknown;
 
-  deleteRecentContacts(peer: Peer): unknown; // 猜测
+  deleteRecentContacts (peer: Peer): unknown;
 
-  getContacts(peers: Peer[]): Promise<unknown>;
+  getContacts (peers: Peer[]): Promise<unknown>;
 
-  setThirdPartyBusinessInfos(...args: unknown[]): unknown; // 1 arguments
+  setThirdPartyBusinessInfos (arg: unknown): unknown;
 
-  updateGameMsgConfigs(...args: unknown[]): unknown; // 1 arguments
+  updateGameMsgConfigs (arg: unknown): unknown;
 
-  removeKernelRecentContactListener(listenerid: number): unknown; // 1 arguments
+  removeKernelRecentContactListener (listenerId: number): unknown;
 
-  addKernelRecentContactListener(listener: NodeIKernelRecentContactListener): void;
+  addKernelRecentContactListener (listener: NodeIKernelRecentContactListener): void;
 
-  clearRecentContactsByChatType(...args: unknown[]): unknown; // 1 arguments
+  clearRecentContactsByChatType (chatType: ChatType): unknown;
 
-  upInsertModule(...args: unknown[]): unknown; // 1 arguments
+  upInsertModule (arg: unknown): unknown;
 
-  jumpToSpecifyRecentContactVer2(...args: unknown[]): unknown; // 1 arguments
+  jumpToSpecifyRecentContactVer2 (arg: unknown): unknown;
 
-  deleteRecentContactsVer2(...args: unknown[]): unknown; // 1 arguments
+  deleteRecentContactsVer2 (arg: unknown): unknown;
 
-  getRecentContactList(): Promise<unknown>;
+  getRecentContactList (): Promise<unknown>;
 
-  getMsgUnreadCount(): unknown;
+  getMsgUnreadCount (): unknown;
 
-  clearRecentContacts(): unknown;
+  clearRecentContacts (): unknown;
 
-  getServiceAssistantRecentContactInfos(): unknown;
+  getServiceAssistantRecentContactInfos (): unknown;
 
-  getRecentContactInfos(): unknown;
+  getRecentContactInfos (): unknown;
 
-  getUnreadDetailsInfos(): unknown;
+  getUnreadDetailsInfos (): unknown;
 
-  cleanAllModule(): unknown;
+  cleanAllModule (): unknown;
 
-  setAllGameMsgRead(): unknown;
+  setAllGameMsgRead (): unknown;
 
-  getRecentContactListSync(): unknown;
+  getRecentContactListSync (): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelRemotingService.ts
+++ b/packages/napcat-core/services/NodeIKernelRemotingService.ts
@@ -1,0 +1,17 @@
+export interface NodeIKernelRemotingService {
+  addKernelRemotingListener (listener: unknown): number;
+
+  removeKernelRemotingListener (listenerId: number): void;
+
+  accept (arg1: string, arg2: boolean): unknown;
+
+  setPenetrateBuffer (arg1: number, arg2: number, arg3: string): unknown;
+
+  startRemotingClient (arg: unknown): unknown;
+
+  startRemotingInvite (arg: unknown): unknown;
+
+  stopRemoting (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelRichMediaService.ts
+++ b/packages/napcat-core/services/NodeIKernelRichMediaService.ts
@@ -62,7 +62,7 @@ export interface NodeIKernelRichMediaService {
   //     KHAND,
   //     KAUTO
   // }
-  getVideoPlayUrl(peer: Peer, msgId: string, elemId: string, videoCodecFormat: number, VideoRequestWay: number): Promise<unknown>;
+  getVideoPlayUrl (peer: Peer, msgId: string, elemId: string, videoCodecFormat: number, VideoRequestWay: number): Promise<unknown>;
 
   // exParams (RMReqExParams)
   // this.downSourceType = i2;
@@ -81,9 +81,9 @@ export interface NodeIKernelRichMediaService {
   // public static final int KTRIGGERTYPEAUTO = 1;
   // public static final int KTRIGGERTYPEMANUAL = 0;
 
-  getVideoPlayUrlV2(peer: Peer, msgId: string, elemId: string, videoCodecFormat: number, exParams: {
+  getVideoPlayUrlV2 (peer: Peer, msgId: string, elemId: string, videoCodecFormat: number, exParams: {
     downSourceType: number,
-    triggerType: number
+    triggerType: number;
   }): Promise<GeneralCallResult & {
     urlResult: {
       v4IpUrl: [],
@@ -91,15 +91,15 @@ export interface NodeIKernelRichMediaService {
       domainUrl: Array<{
         url: string,
         isHttps: boolean,
-        httpsDomain: string
+        httpsDomain: string;
       }>,
-      videoCodecFormat: number
-    }
+      videoCodecFormat: number;
+    };
   }>;
 
-  getRichMediaFileDir(elementType: number, downType: number, isTemp: boolean): unknown;
+  getRichMediaFileDir (elementType: number, downType: number, isTemp: boolean): unknown;
 
-  getVideoPlayUrlInVisit(arg: {
+  getVideoPlayUrlInVisit (arg: {
     downloadType: number,
     thumbSize: number,
     msgId: string,
@@ -111,17 +111,17 @@ export interface NodeIKernelRichMediaService {
     peerUid: string,
     guildId: string,
     ele: MessageElement,
-    useHttps: boolean
+    useHttps: boolean;
   }): Promise<unknown>;
 
-  isFileExpired(arg: number): unknown;
+  isFileExpired (arg: number): unknown;
 
-  deleteGroupFolder(GroupCode: string, FolderId: string): Promise<GeneralCallResult & {
-    groupFileCommonResult: { retCode: number, retMsg: string, clientWording: string }
+  deleteGroupFolder (GroupCode: string, FolderId: string): Promise<GeneralCallResult & {
+    groupFileCommonResult: { retCode: number, retMsg: string, clientWording: string; };
   }>;
 
   // 参数与getVideoPlayUrlInVisit一样
-  downloadRichMediaInVisit(arg: {
+  downloadRichMediaInVisit (arg: {
     downloadType: number,
     thumbSize: number,
     msgId: string,
@@ -133,10 +133,10 @@ export interface NodeIKernelRichMediaService {
     peerUid: string,
     guildId: string,
     ele: MessageElement,
-    useHttps: boolean
+    useHttps: boolean;
   }): unknown;
 
-  downloadFileForModelId(peer: Peer, ModelId: string[], unknown: string): Promise<unknown>;
+  downloadFileForModelId (peer: Peer, ModelId: string[], unknown: string): Promise<unknown>;
 
   // 第三个参数 Array<Type>
   // this.fileId = "";
@@ -146,83 +146,83 @@ export interface NodeIKernelRichMediaService {
   // this.fileSize = j2;
   // this.fileModelId = j3;
 
-  downloadFileForFileUuid(peer: Peer, uuid: string, arg3: {
+  downloadFileForFileUuid (peer: Peer, uuid: string, arg3: {
     fileId: string,
     fileName: string,
     fileSize: string,
-    fileModelId: string
+    fileModelId: string;
   }[]): Promise<unknown>;
 
-  downloadFileByUrlList(fileDownloadTyp: UrlFileDownloadType, urlList: Array<string>): unknown;
+  downloadFileByUrlList (fileDownloadTyp: UrlFileDownloadType, urlList: Array<string>): unknown;
 
-  downloadFileForFileInfo(fileInfo: CommonFileInfo[], savePath: string): unknown;
+  downloadFileForFileInfo (fileInfo: CommonFileInfo[], savePath: string): unknown;
 
-  createGroupFolder(GroupCode: string, FolderName: string): Promise<GeneralCallResult & {
-    resultWithGroupItem: { result: unknown, groupItem: Array<unknown> }
+  createGroupFolder (GroupCode: string, FolderName: string): Promise<GeneralCallResult & {
+    resultWithGroupItem: { result: unknown, groupItem: Array<unknown>; };
   }>;
 
-  downloadFile(commonFile: CommonFileInfo, arg2: unknown, arg3: unknown, savePath: string): unknown;
+  downloadFile (arg1: unknown, arg2: number, arg3: number, arg4: string): unknown;
 
-  createGroupFolder(arg1: unknown, arg2: unknown): unknown;
+  createGroupFolder (arg1: unknown, arg2: unknown): unknown;
 
-  downloadGroupFolder(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  downloadGroupFolder (arg1: string, arg2: string, arg3: string): unknown;
 
-  renameGroupFolder(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  renameGroupFolder (arg1: string, arg2: string, arg3: string): unknown;
 
-  deleteGroupFolder(arg1: unknown, arg2: unknown): unknown;
+  deleteGroupFolder (arg1: unknown, arg2: unknown): unknown;
 
-  deleteTransferInfo(arg1: unknown, arg2: unknown): unknown;
+  deleteTransferInfo (arg1: unknown, arg2: unknown): unknown;
 
-  cancelTransferTask(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  cancelTransferTask (arg1: Peer, arg2: Array<unknown>[], arg3: string): unknown;
 
-  cancelUrlDownload(arg: unknown): unknown;
+  cancelUrlDownload (arg: unknown): unknown;
 
-  updateOnlineVideoElemStatus(arg: unknown): unknown;
+  updateOnlineVideoElemStatus (arg: unknown): unknown;
 
-  getGroupSpace(arg: unknown): unknown;
+  getGroupSpace (arg: unknown): unknown;
 
-  getGroupFileList(groupCode: string, params: GetFileListParam): Promise<GeneralCallResult & {
+  getGroupFileList (groupCode: string, params: GetFileListParam): Promise<GeneralCallResult & {
     groupSpaceResult: {
-      retCode: number
-      retMsg: string
-      clientWording: string
-      totalSpace: number
-      usedSpace: number
-      allUpload: boolean
-    }
+      retCode: number;
+      retMsg: string;
+      clientWording: string;
+      totalSpace: number;
+      usedSpace: number;
+      allUpload: boolean;
+    };
   }>;
 
-  getGroupFileInfo(arg1: unknown, arg2: unknown): unknown;
+  getGroupFileInfo (arg1: unknown, arg2: unknown): unknown;
 
-  getGroupTransferList(arg1: unknown, arg2: unknown): unknown;
+  getGroupTransferList (arg1: string, arg2: unknown): unknown;
 
-  renameGroupFile(arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown, arg5: unknown): unknown;
+  renameGroupFile (arg1: string, arg2: number, arg3: string, arg4: string, arg5: string): unknown;
 
-  moveGroupFile(groupCode: string, busId: Array<number>, fileList: Array<string>, currentParentDirectory: string, targetParentDirectory: string): Promise<GeneralCallResult & {
+  moveGroupFile (groupCode: string, busId: Array<number>, fileList: Array<string>, currentParentDirectory: string, targetParentDirectory: string): Promise<GeneralCallResult & {
     moveGroupFileResult: {
       result: {
         retCode: number,
         retMsg: symbol,
-        clientWording: string
+        clientWording: string;
       },
       successFileIdList: Array<string>,
-      failFileIdList: Array<string>
-    }
+      failFileIdList: Array<string>;
+    };
   }>;
 
-  transGroupFile(groupCode: string, fileId: string): Promise<GeneralCallResult & {
+  transGroupFile (groupCode: string, fileId: string): Promise<GeneralCallResult & {
     transGroupFileResult: {
       result: {
-        retCode: number
-        retMsg: string
-        clientWording: string
-      }
-      saveBusId: number
-      saveFilePath: string
-    }
+        retCode: number;
+        retMsg: string;
+        clientWording: string;
+      };
+      saveBusId: number;
+      saveFilePath: string;
+    };
   }>;
 
-  searchGroupFile(
+  searchGroupFile (
     keywords: Array<string>,
     param: {
       groupIds: Array<string>,
@@ -230,55 +230,57 @@ export interface NodeIKernelRichMediaService {
       context: string,
       count: number,
       sortType: number,
-      groupNames: Array<string>
+      groupNames: Array<string>;
     }): Promise<unknown>;
 
-  searchGroupFileByWord(arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown, arg5: unknown): unknown;
+  searchGroupFileByWord (arg1: unknown[], arg2: unknown[], arg3: string, arg4: string, arg5: number): unknown;
 
-  deleteGroupFile(GroupCode: string, params: Array<number>, Files: Array<string>): Promise<GeneralCallResult & {
+  deleteGroupFile (GroupCode: string, params: Array<number>, Files: Array<string>): Promise<GeneralCallResult & {
     transGroupFileResult: {
-      result: unknown
-      successFileIdList: Array<unknown>
-      failFileIdList: Array<unknown>
-    }
+      result: unknown;
+      successFileIdList: Array<unknown>;
+      failFileIdList: Array<unknown>;
+    };
   }>;
 
-  translateEnWordToZn(words: string[]): Promise<GeneralCallResult & { words: string[] }>;
+  translateEnWordToZn (words: string[]): Promise<GeneralCallResult & { words: string[]; }>;
 
-  getScreenOCR(path: string): Promise<unknown>;
+  getScreenOCR (path: string): Promise<unknown>;
 
-  batchGetGroupFileCount(Gids: Array<string>): Promise<GeneralCallResult & {
+  batchGetGroupFileCount (Gids: Array<string>): Promise<GeneralCallResult & {
     groupCodes: Array<string>,
-    groupFileCounts: Array<number>
+    groupFileCounts: Array<number>;
   }>;
 
-  queryPicDownloadSize(arg: unknown): unknown;
+  queryPicDownloadSize (arg: unknown): unknown;
 
-  searchGroupFile(arg1: unknown, arg2: unknown): unknown;
+  searchGroupFile (arg1: unknown, arg2: unknown): unknown;
 
-  searchMoreGroupFile(arg: unknown): unknown;
+  searchMoreGroupFile (arg: unknown): unknown;
 
-  cancelSearcheGroupFile(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  cancelSearcheGroupFile (arg1: number, arg2: number, arg3: string): unknown;
 
-  onlyDownloadFile(peer: Peer, arg2: unknown, arg3: Array<{
-    fileId: string,
-    fileName: string,
-    fileSize: string,
-    fileModelId: string
-  }
-    >): unknown;
+  onlyDownloadFile (arg1: Peer, arg2: string, arg3: Array<unknown>[]): unknown;
 
-  onlyUploadFile(arg1: unknown, arg2: unknown): unknown;
+  onlyUploadFile (arg1: unknown, arg2: unknown): unknown;
 
-  isExtraLargePic(arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+  isExtraLargePic (arg1: unknown, arg2: unknown, arg3: unknown): unknown;
 
-  uploadRMFileWithoutMsg(arg: {
+  uploadRMFileWithoutMsg (arg: {
     bizType: RMBizTypeEnum,
     filePath: string,
     peerUid: string,
-    transferId: string
-    useNTV2: string
+    transferId: string;
+    useNTV2: string;
   }): Promise<unknown>;
 
-  isNull(): boolean;
+  isNull (): boolean;
+
+  getRichMediaCodecInfo (arg: unknown): unknown;
+
+  getScreenOCRWithSourceType (arg1: unknown, arg2: unknown): unknown;
+
+  imageTranslate (arg1: string, arg2: string, arg3: number): unknown;
+
+  downloadFileByUrl (arg1: number, arg2: string, arg3: boolean): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelRobotService.ts
+++ b/packages/napcat-core/services/NodeIKernelRobotService.ts
@@ -2,47 +2,127 @@ import { NodeIKernelRobotListener } from '@/napcat-core/listeners';
 import { GeneralCallResult, Peer } from '..';
 
 export interface NodeIKernelRobotService {
-  fetchGroupRobotStoreDiscovery(arg: unknown): unknown;
+  addKernelRobotListener (listener: NodeIKernelRobotListener): number;
 
-  sendGroupRobotStoreSearch(arg: unknown): unknown;
+  removeKernelRobotListener (listenerId: number): void;
 
-  fetchGroupRobotStoreCategoryList(arg: unknown): unknown;
+  fetchGroupRobotStoreDiscovery (arg: unknown): unknown;
 
-  FetchSubscribeMsgTemplate(arg: unknown): unknown;
+  fetchGroupRobotStoreCategoryList (arg: unknown): unknown;
 
-  FetchSubcribeMsgTemplateStatus(arg: unknown): unknown;
+  FetchSubscribeMsgTemplate (arg: unknown): unknown;
 
-  SubscribeMsgTemplateSet(arg1: unknown, arg2: unknown): unknown;
+  FetchSubcribeMsgTemplateStatus (arg: unknown): unknown;
 
-  fetchRecentUsedRobots(arg: unknown): unknown;
+  SubscribeMsgTemplateSet (arg1: unknown, arg2: unknown): unknown;
 
-  fetchShareArkInfo(arg: unknown): unknown;
+  fetchRecentUsedRobots (arg: unknown): unknown;
 
-  addKernelRobotListener(Listener: NodeIKernelRobotListener): number;
+  fetchShareArkInfo (arg: unknown): unknown;
 
-  removeKernelRobotListener(ListenerId: number): unknown;
+  getAllRobotFriendsFromCache (): Promise<unknown>;
 
-  getAllRobotFriendsFromCache(): Promise<unknown>;
+  fetchAllRobots (arg1: boolean, arg2: unknown): unknown;
 
-  fetchAllRobots(arg1: unknown, arg2: unknown): unknown;
+  removeAllRecommendCache (): unknown;
 
-  removeAllRecommendCache(): unknown;
+  setRobotPickTts (arg1: unknown, arg2: unknown): unknown;
 
-  setRobotPickTts(arg1: unknown, arg2: unknown): unknown;
+  getRobotUinRange (data: unknown): Promise<{ response: { robotUinRanges: Array<unknown>; }; }>;
 
-  getRobotUinRange(data: unknown): Promise<{ response: { robotUinRanges: Array<unknown> } }>;
-
-  getRobotFunctions(peer: Peer, params: {
+  getRobotFunctions (peer: Peer, params: {
     uins: Array<string>,
     num: 0,
-    client_info: { platform: 4, version: '', build_num: 9999 },
+    client_info: { platform: 4, version: '', build_num: 9999; },
     tinyids: [],
     page: 0,
     full_fetch: false,
     scene: 4,
     filter: 1,
-    bkn: ''
-  }): Promise<GeneralCallResult & { response: { bot_features: Array<unknown>, next_page: number } }>;
+    bkn: '';
+  }): Promise<GeneralCallResult & { response: { bot_features: Array<unknown>, next_page: number; }; }>;
 
-  isNull(): boolean;
+  fetchRobotShareLimit (arg1: unknown, arg2: unknown): unknown;
+
+  updateGroupRobotProfile (arg1: unknown, arg2: unknown): unknown;
+
+  sendCommonRobotToGuild (arg1: unknown, arg2: unknown): unknown;
+
+  sendGroupRobotStoreSearch (arg: unknown): unknown;
+
+  fetchMyRobotLists (arg: unknown): unknown;
+
+  batchGetBotsMenu (arg: unknown): unknown;
+
+  fetchAddRobotGroupList (arg: unknown): unknown;
+
+  getGuildRobotList (arg: unknown): unknown;
+
+  querySessionList (arg: unknown): unknown;
+
+  fetchListRobot (arg: unknown): unknown;
+
+  subscribeGuildGlobalRobot (arg: unknown): unknown;
+
+  addGuildRobot (arg: unknown): unknown;
+
+  upMicGuildRobot (arg: unknown): unknown;
+
+  downMicGuildRobot (arg: unknown): unknown;
+
+  getRedDot (arg: unknown): unknown;
+
+  delRedDot (arg: unknown): unknown;
+
+  changeMyBot (arg: unknown): unknown;
+
+  getAudioLiveRobotStatus (arg: unknown): unknown;
+
+  backFlowRobotCoreInfos (arg: unknown): unknown;
+
+  batchFetchRobotCoreInfos (arg: unknown): unknown;
+
+  queryPicRecomQuestions (arg: unknown): unknown;
+
+  delSessionMsgs (arg: unknown): unknown;
+
+  fetchMobileRobotRecommendCards (arg: unknown): unknown;
+
+  saveSelectedAIModelOrOptIds (arg: unknown): unknown;
+
+  setRobotStoryEnter (arg: unknown): unknown;
+
+  aiGenAvatar (arg: unknown): unknown;
+
+  fetchRobotFeatureWithReq (arg: unknown): unknown;
+
+  fetchGroupRobotProfileWithReq (arg: unknown): unknown;
+
+  setAddRobotToGroup (arg: unknown): unknown;
+
+  setRemoveRobotFromGroup (arg: unknown): unknown;
+
+  FetchGroupRobotInfo (arg: unknown): unknown;
+
+  fetchGuildRobotInfo (arg: unknown): unknown;
+
+  aiGenBotInfo (arg: unknown): unknown;
+
+  fetchAiGenTemplateInfo (arg: unknown): unknown;
+
+  fetchShareInfo (arg: unknown): unknown;
+
+  updateShareInfo (arg: unknown): unknown;
+
+  queryGuildGlobalRobotSubscription (arg: unknown): unknown;
+
+  resetConversation (arg: unknown): unknown;
+
+  setGuildRobotPermission (arg: unknown): unknown;
+
+  fetchGuildRobotPermission (arg: unknown): unknown;
+
+  editSession (arg: unknown): unknown;
+
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelSearchService.ts
+++ b/packages/napcat-core/services/NodeIKernelSearchService.ts
@@ -3,134 +3,146 @@ import { GeneralCallResult } from './common';
 
 export interface NodeIKernelSearchService {
 
-  addKernelSearchListener(listener: unknown): number;
+  addKernelSearchListener (listener: unknown): number;
 
-  removeKernelSearchListener(listenerId: number): void;
+  removeKernelSearchListener (listenerId: number): void;
 
-  searchStranger(unknown: string, searchStranger: unknown, searchParams: unknown): Promise<unknown>;
+  searchStranger (keyword: string, searchType: unknown, searchParams: unknown): Promise<unknown>;
 
-  searchGroup(param: {
+  searchGroup (param: {
     keyWords: string,
     groupNum: number,
     exactSearch: boolean,
-    penetrate: string
-  }): Promise<GeneralCallResult>;// needs 1 arguments
+    penetrate: string;
+  }): Promise<GeneralCallResult>;
 
-  searchLocalInfo(keywords: string, type: number/* 4 */): unknown;
+  searchLocalInfo (keywords: string, type: number): unknown;
 
-  cancelSearchLocalInfo(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchLocalInfo (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchBuddyChatInfo(...args: unknown[]): unknown;// needs 2 arguments
+  searchBuddyChatInfo (arg1: unknown, arg2: unknown): unknown;
 
-  searchMoreBuddyChatInfo(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreBuddyChatInfo (arg: unknown): unknown;
 
-  cancelSearchBuddyChatInfo(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchBuddyChatInfo (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchContact(...args: unknown[]): unknown;// needs 2 arguments
+  searchContact (arg1: Array<unknown>[], arg2: unknown): unknown;
 
-  searchMoreContact(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreContact (arg: unknown): unknown;
 
-  cancelSearchContact(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchContact (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchGroupChatInfo(...args: unknown[]): unknown;// needs 3 arguments
+  searchGroupChatInfo (arg1: unknown[], arg2: unknown, arg3: number): unknown;
 
-  resetSearchGroupChatInfoSortType(...args: unknown[]): unknown;// needs 3 arguments
+  resetSearchGroupChatInfoSortType (arg1: number, arg2: number, arg3: number): unknown;
 
-  resetSearchGroupChatInfoFilterMembers(...args: unknown[]): unknown;// needs 3 arguments
+  resetSearchGroupChatInfoFilterMembers (arg1: number, arg2: Array<unknown>[], arg3: number): unknown;
 
-  searchMoreGroupChatInfo(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreGroupChatInfo (arg: unknown): unknown;
 
-  cancelSearchGroupChatInfo(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchGroupChatInfo (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchChatsWithKeywords(...args: unknown[]): unknown;// needs 3 arguments
+  searchChatsWithKeywords (arg1: unknown[], arg2: number, arg3: number): unknown;
 
-  searchMoreChatsWithKeywords(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreChatsWithKeywords (arg: unknown): unknown;
 
-  cancelSearchChatsWithKeywords(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchChatsWithKeywords (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchChatMsgs(...args: unknown[]): unknown;// needs 2 arguments
+  searchChatMsgs (arg1: Array<unknown>[], arg2: unknown): unknown;
 
-  searchMoreChatMsgs(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreChatMsgs (arg: unknown): unknown;
 
-  cancelSearchChatMsgs(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchChatMsgs (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchMsgWithKeywords(keyWords: string[], param: Peer & { searchFields: number, pageLimit: number }): Promise<GeneralCallResult>;
+  searchMsgWithKeywords (keyWords: string[], param: Peer & { searchFields: number, pageLimit: number; }): Promise<GeneralCallResult>;
 
-  searchMoreMsgWithKeywords(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreMsgWithKeywords (arg: unknown): unknown;
 
-  cancelSearchMsgWithKeywords(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchMsgWithKeywords (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchFileWithKeywords(keywords: string[], source: number): Promise<string>;// needs 2 arguments
+  searchFileWithKeywords (keywords: string[], source: number): Promise<string>;
 
-  searchMoreFileWithKeywords(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreFileWithKeywords (arg: unknown): unknown;
 
-  cancelSearchFileWithKeywords(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchFileWithKeywords (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchAtMeChats(...args: unknown[]): unknown;// needs 3 arguments
+  searchFileInFileCenterForPC (arg1: unknown, arg2: unknown): unknown;
 
-  searchMoreAtMeChats(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreFileInFileCenter (arg: unknown): unknown;
 
-  cancelSearchAtMeChats(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchFileInFileCenter (arg1: number, arg2: number, arg3: string): unknown;
 
-  searchChatAtMeMsgs(...args: unknown[]): unknown;// needs 1 arguments
+  searchAtMeChats (arg1: boolean, arg2: number, arg3: number): unknown;
 
-  searchMoreChatAtMeMsgs(...args: unknown[]): unknown;// needs 1 arguments
+  searchMoreAtMeChats (arg: unknown): unknown;
 
-  cancelSearchChatAtMeMsgs(...args: unknown[]): unknown;// needs 3 arguments
+  cancelSearchAtMeChats (arg1: number, arg2: number, arg3: string): unknown;
 
-  addSearchHistory(param: {
-    type: number, // 4
+  searchChatAtMeMsgs (arg: unknown): unknown;
+
+  searchMoreChatAtMeMsgs (arg: unknown): unknown;
+
+  cancelSearchChatAtMeMsgs (arg1: number, arg2: number, arg3: string): unknown;
+
+  searchRobot (arg: unknown): unknown;
+
+  searchCache (arg1: string, arg2: string, arg3: unknown): unknown;
+
+  addSearchHistory (param: {
+    type: number,
     contactList: [],
-    id: number, // -1
+    id: number,
     groupInfos: [],
     msgs: [],
-    fileInfos: [
-      {
-        chatType: ChatType,
-        buddyChatInfo: Array<{ category_name: string, peerUid: string, peerUin: string, remark: string }>,
-        discussChatInfo: [],
-        groupChatInfo: Array<
-                    {
-                      groupCode: string,
-                      isConf: boolean,
-                      hasModifyConfGroupFace: boolean,
-                      hasModifyConfGroupName: boolean,
-                      groupName: string,
-                      remark: string
-                    }>,
-        dataLineChatInfo: [],
-        tmpChatInfo: [],
-        msgId: string,
-        msgSeq: string,
-        msgTime: string,
-        senderUid: string,
-        senderNick: string,
-        senderRemark: string,
-        senderCard: string,
-        elemId: string,
-        elemType: string, // 3
-        fileSize: string,
-        filePath: string,
-        fileName: string,
-        hits: Array<
-                    {
-                      start: 12,
-                      end: 14
-                    }
-                >
-      }
-    ]
-
+    fileInfos: Array<{
+      chatType: ChatType,
+      buddyChatInfo: Array<{ category_name: string, peerUid: string, peerUin: string, remark: string; }>,
+      discussChatInfo: [],
+      groupChatInfo: Array<{
+        groupCode: string,
+        isConf: boolean,
+        hasModifyConfGroupFace: boolean,
+        hasModifyConfGroupName: boolean,
+        groupName: string,
+        remark: string;
+      }>,
+      dataLineChatInfo: [],
+      tmpChatInfo: [],
+      msgId: string,
+      msgSeq: string,
+      msgTime: string,
+      senderUid: string,
+      senderNick: string,
+      senderRemark: string,
+      senderCard: string,
+      elemId: string,
+      elemType: string,
+      fileSize: string,
+      filePath: string,
+      fileName: string,
+      hits: Array<{ start: number, end: number; }>;
+    }>;
   }): Promise<{
     result: number,
     errMsg: string,
-    id?: number
+    id?: number;
   }>;
 
-  removeSearchHistory(...args: unknown[]): unknown;// needs 1 arguments
+  removeSearchHistory (arg: unknown): unknown;
 
-  searchCache(...args: unknown[]): unknown;// needs 3 arguments
+  addOrUpdateSearchMostUseItem (arg1: unknown, arg2: unknown): unknown;
 
-  clearSearchCache(...args: unknown[]): unknown;// needs 1 arguments
+  getSearchMostUseItem (arg: unknown): unknown;
 
+  deleteSearchMostUseItem (arg: unknown): unknown;
+
+  deleteGroupHistoryFile (arg: unknown): unknown;
+
+  clearSearchCache (arg: unknown): unknown;
+
+  clearSearchHistory (): unknown;
+
+  loadSearchHistory (): unknown;
+
+  initTokenizeUtil (): unknown;
 }

--- a/packages/napcat-core/services/NodeIKernelSettingService.ts
+++ b/packages/napcat-core/services/NodeIKernelSettingService.ts
@@ -1,0 +1,53 @@
+export interface NodeIKernelSettingService {
+  addKernelSettingListener (listener: unknown): number;
+
+  removeKernelSettingListener (listenerId: number): void;
+
+  getSettingForBuffer (key: unknown): unknown;
+
+  getSettingForNum (key: unknown): unknown;
+
+  getSettingForStr (key: unknown): unknown;
+
+  setSettingForBuffer (arg: unknown): unknown;
+
+  setSettingForNum (arg: unknown): unknown;
+
+  setSettingForStr (arg: unknown): unknown;
+
+  setAutoLoginSwitch (enabled: boolean): unknown;
+
+  setNeedConfirmSwitch (enabled: boolean): unknown;
+
+  setPrivacySetting (arg: unknown): unknown;
+
+  setSelfStartSwitch (enabled: boolean): unknown;
+
+  modifyAccount (arg: unknown): unknown;
+
+  verifyNewAccount (arg: unknown): unknown;
+
+  openUrlWithQQBrowser (url: string): unknown;
+
+  openUrlInIM (url: string): unknown;
+
+  clearCache (arg: unknown): unknown;
+
+  destroyAccount (): unknown;
+
+  isQQBrowserInstall (): boolean;
+
+  getSelfStartSwitch (): unknown;
+
+  getAutoLoginSwitch (): unknown;
+
+  getNeedConfirmSwitch (): unknown;
+
+  getPrivacySetting (): unknown;
+
+  scanCache (): unknown;
+
+  getQQBrowserSwitchFromQldQQ (): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelSkinService.ts
+++ b/packages/napcat-core/services/NodeIKernelSkinService.ts
@@ -1,0 +1,21 @@
+export interface NodeIKernelSkinService {
+  addKernelSkinListener (listener: unknown): number;
+
+  removeKernelSkinListener (listenerId: number): void;
+
+  getRecommendAIOColor (arg1: unknown, arg2: unknown): unknown;
+
+  getRecommendBubbleColor (arg1: unknown, arg2: unknown): unknown;
+
+  getThemeInfoFromImage (arg: unknown): unknown;
+
+  previewTheme (arg1: number, arg2: unknown, arg3: unknown): unknown;
+
+  setTemplateCustomPrimaryColor (arg1: unknown, arg2: unknown): unknown;
+
+  setThemeInfo (arg1: number, arg2: unknown, arg3: unknown): unknown;
+
+  uploadImage (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelStorageCleanService.ts
+++ b/packages/napcat-core/services/NodeIKernelStorageCleanService.ts
@@ -36,15 +36,15 @@ export interface NodeIKernelStorageCleanService {
 
   reportData (): unknown;
 
-  getChatCacheInfo (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown): unknown;
+  getChatCacheInfo (tableType: number, pageSize: number, order: number, startPosition: number): Promise<unknown>;
 
-  getFileCacheInfo (arg1: unknown, arg2: unknown, arg3: unknown, arg44: unknown, args5: unknown): unknown;
+  getFileCacheInfo (fileType: number, restart: boolean, pageSize: number, lastRecord: number, param: unknown): Promise<unknown>;
 
-  clearChatCacheInfo (arg1: unknown, arg2: unknown): unknown;
+  clearChatCacheInfo (chatInfoList: unknown[], clearKeys: number[]): Promise<unknown>;
 
   clearCacheDataByKeys (keys: Array<string>): Promise<GeneralCallResult>;
 
-  setSilentScan (is_silent: boolean): unknown;
+  setSilentScan (isSilent: boolean): unknown;
 
   closeCleanWindow (): unknown;
 

--- a/packages/napcat-core/services/NodeIKernelThirdPartySigService.ts
+++ b/packages/napcat-core/services/NodeIKernelThirdPartySigService.ts
@@ -1,0 +1,17 @@
+export interface NodeIKernelThirdPartySigService {
+  addOnSigChangeListener (listener: unknown): number;
+
+  removeSigChangeListener (listenerId: number): void;
+
+  initConfig (arg: unknown): unknown;
+
+  delThirdPartySigByUin (arg: unknown): unknown;
+
+  getOpenIDByUin (arg1: string, arg2: number, arg3: string): unknown;
+
+  getPT4tokenByUin (arg1: string, arg2: number, arg3: Array<unknown>[]): unknown;
+
+  getThirdPartySigByUin (arg1: string, arg2: number, arg3: number, arg4: number, arg5: string, arg6: string): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelTianShuService.ts
+++ b/packages/napcat-core/services/NodeIKernelTianShuService.ts
@@ -1,8 +1,8 @@
 export interface NodeIKernelTianShuService {
-  addKernelTianShuListener(listener:unknown): number;
+  addKernelTianShuListener (listener: unknown): number;
 
-  removeKernelTianShuListener(listenerId:number): void;
+  removeKernelTianShuListener (listenerId: number): void;
 
-  reportTianShuNumeralRed(...args: unknown[]): unknown;// needs 1 arguments
+  reportTianShuNumeralRed (arg: unknown): unknown;// needs 1 arguments
 
 }

--- a/packages/napcat-core/services/NodeIKernelTicketService.ts
+++ b/packages/napcat-core/services/NodeIKernelTicketService.ts
@@ -2,11 +2,11 @@ import { ForceFetchClientKeyRetType } from './common';
 
 export interface NodeIKernelTicketService {
 
-  addKernelTicketListener(listener: unknown): number;
+  addKernelTicketListener (listener: unknown): number;
 
-  removeKernelTicketListener(listenerId: number): void;
+  removeKernelTicketListener (listenerId: number): void;
 
-  forceFetchClientKey(arg: string): Promise<ForceFetchClientKeyRetType>;
+  forceFetchClientKey (arg: string): Promise<ForceFetchClientKeyRetType>;
 
-  isNull(): boolean;
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelTipOffService.ts
+++ b/packages/napcat-core/services/NodeIKernelTipOffService.ts
@@ -2,21 +2,19 @@ import { GeneralCallResult } from './common';
 
 export interface NodeIKernelTipOffService {
 
-  addKernelTipOffListener(listener: unknown): number;
+  addKernelTipOffListener (listener: unknown): number;
 
-  removeKernelTipOffListener(listenerId: unknown): void;
+  removeKernelTipOffListener (listenerId: number): void;
 
-  tipOffSendJsData(args: unknown[]): Promise<unknown>;// 2
+  tipOffSendJsData (arg1: unknown, arg2: unknown): Promise<unknown>;
 
-  getPskey(domainList: string[], nocache: boolean): Promise<GeneralCallResult & {
-    domainPskeyMap: Map<string, string>
+  getPskey (domainList: string[], nocache: boolean): Promise<GeneralCallResult & {
+    domainPskeyMap: Map<string, string>;
   }>;
 
-  tipOffSendJsData(args: unknown[]): Promise<unknown>;// 2
+  tipOffMsgs (arg: unknown): Promise<unknown>;
 
-  tipOffMsgs(args: unknown[]): Promise<unknown>;// 1
+  encodeUinAesInfo (arg1: unknown, arg2: unknown): Promise<unknown>;
 
-  encodeUinAesInfo(args: unknown[]): Promise<unknown>;// 2
-
-  isNull(): boolean;
+  isNull (): boolean;
 }

--- a/packages/napcat-core/services/NodeIKernelUnifySearchService.ts
+++ b/packages/napcat-core/services/NodeIKernelUnifySearchService.ts
@@ -1,0 +1,23 @@
+export interface NodeIKernelUnifySearchService {
+  checkAIAuth (arg: unknown): unknown;
+
+  getNetResultTabs (arg: unknown): unknown;
+
+  getNetSugWords (arg: unknown): unknown;
+
+  getSearchAppendingInfo (arg: unknown): unknown;
+
+  getSearchBoxSugWords (arg: unknown): unknown;
+
+  search (arg: unknown): unknown;
+
+  unifySearch (arg: unknown): unknown;
+
+  unifySearchDiscovery (arg: unknown): unknown;
+
+  unifySearchDiscoveryInCache (arg: unknown): unknown;
+
+  wxSearchReport (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelUnitedConfigService.ts
+++ b/packages/napcat-core/services/NodeIKernelUnitedConfigService.ts
@@ -1,17 +1,17 @@
 export interface NodeIKernelUnitedConfigService {
 
-  addKernelUnitedConfigListener(listener:unknown): number;
+  addKernelUnitedConfigListener (listener: unknown): number;
 
-  removeKernelUnitedConfigListener(listenerId:number): void;
+  removeKernelUnitedConfigListener (listenerId: number): void;
 
-  fetchUnitedSwitchConfig(...args: unknown[]): unknown;// needs 1 arguments
+  fetchUnitedSwitchConfig (configIds: string[]): void;
 
-  isUnitedConfigSwitchOn(...args: unknown[]): unknown;// needs 1 arguments
+  isUnitedConfigSwitchOn (configId: string): boolean;
 
-  registerUnitedConfigPushGroupList(...args: unknown[]): unknown;// needs 1 arguments
+  registerUnitedConfigPushGroupList (groupList: string[]): void;
 
-  fetchUnitedCommendConfig(ids: `${string}`[]): void
+  fetchUnitedCommendConfig (ids: string[]): void;
 
-  loadUnitedConfig(id: string): Promise<unknown>
+  loadUnitedConfig (id: string): Promise<unknown>;
 
 }

--- a/packages/napcat-core/services/NodeIKernelVasSystemUpdateService.ts
+++ b/packages/napcat-core/services/NodeIKernelVasSystemUpdateService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelVasSystemUpdateService {
+  getResPath (arg: unknown): unknown;
+
+  isExist (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelWiFiPhotoClientService.ts
+++ b/packages/napcat-core/services/NodeIKernelWiFiPhotoClientService.ts
@@ -1,0 +1,37 @@
+export interface NodeIKernelWiFiPhotoClientService {
+  addKernelWiFiPhotoClientListener (listener: unknown): number;
+
+  removeKernelWiFiPhotoClientListener (listenerId: number): void;
+
+  cancelGetPhoto (arg1: unknown, arg2: unknown): unknown;
+
+  cancelGetPhotoThumbBatch (arg: unknown): unknown;
+
+  cancelRequest (arg: unknown): unknown;
+
+  connectToHostForTest (arg: unknown): unknown;
+
+  deletePhotoBatch (arg: unknown): unknown;
+
+  disconnect (arg: unknown): unknown;
+
+  getAlbumFileSavePath (arg: unknown): unknown;
+
+  getAllPhotoSimpleInfo (arg: unknown): unknown;
+
+  getPhotoAndSaveAs (arg1: string, arg2: string, arg3: string): unknown;
+
+  getPhotoBatch (arg1: unknown, arg2: unknown): unknown;
+
+  getPhotoInfoBatch (arg1: unknown, arg2: unknown): unknown;
+
+  getPhotoSimpleInfoForFirstView (arg1: string, arg2: number): unknown;
+
+  getPhotoThumbBatchWithConfig (arg1: unknown, arg2: unknown): unknown;
+
+  getWiFiPhotoDownFileInfos (arg1: string, arg2: Array<unknown>[]): unknown;
+
+  resumeUncompleteDownloadRecords (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelWiFiPhotoHostService.ts
+++ b/packages/napcat-core/services/NodeIKernelWiFiPhotoHostService.ts
@@ -1,0 +1,15 @@
+export interface NodeIKernelWiFiPhotoHostService {
+  addKernelWiFiPhotoHostListener (listener: unknown): number;
+
+  removeKernelWiFiPhotoHostListener (listenerId: number): void;
+
+  acceptRequest (arg1: number, arg2: unknown): unknown;
+
+  disconnect (arg: unknown): unknown;
+
+  rejectRequest (arg1: number, arg2: number): unknown;
+
+  setAlbumAccessDelegate (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIKernelYellowFaceForManagerService.ts
+++ b/packages/napcat-core/services/NodeIKernelYellowFaceForManagerService.ts
@@ -1,0 +1,7 @@
+export interface NodeIKernelYellowFaceForManagerService {
+  download (arg1: string, arg2: string, arg3: string, arg4: boolean): unknown;
+
+  setHistory (arg: unknown): unknown;
+
+  isNull (): boolean;
+}

--- a/packages/napcat-core/services/NodeIO3MiscService.ts
+++ b/packages/napcat-core/services/NodeIO3MiscService.ts
@@ -1,11 +1,15 @@
 import { NodeIO3MiscListener } from '@/napcat-core/listeners/NodeIO3MiscListener';
 
 export interface NodeIO3MiscService {
-  get(): NodeIO3MiscService;
+  get (): NodeIO3MiscService;
 
-  addO3MiscListener(listeners: NodeIO3MiscListener): number;
+  addO3MiscListener (listener: NodeIO3MiscListener): number;
 
-  setAmgomDataPiece(appid: string, dataPiece: Uint8Array): void;
+  removeO3MiscListener (listenerId: number): void;
 
-  reportAmgomWeather(type: string, uk2: string, arg: Array<string>): void;
+  passthroughO3Data (arg1: unknown, arg2: unknown): unknown;
+
+  reportAmgomWeather (arg1: unknown, arg2: unknown, arg3: unknown): unknown;
+
+  setAmgomDataPiece (appid: string, dataPiece: Uint8Array): void;
 }

--- a/packages/napcat-core/services/NodeIYellowFaceService.ts
+++ b/packages/napcat-core/services/NodeIYellowFaceService.ts
@@ -1,5 +1,11 @@
 export interface NodeIYellowFaceService {
-  download(resourceConfigJson: string, resourceDir: string, cacheDir: string, force: boolean): void;
+  addListener (listener: unknown): number;
 
-  setHistory(fullMd5: string): void;
+  removeListener (listenerId: number): void;
+
+  download (resourceConfigJson: string, resourceDir: string, cacheDir: string, force: boolean): void;
+
+  setHistory (fullMd5: string): void;
+
+  update (arg: unknown): unknown;
 }

--- a/packages/napcat-core/services/index.ts
+++ b/packages/napcat-core/services/index.ts
@@ -36,6 +36,36 @@ export * from './NodeIKernelDbToolsService';
 export * from './NodeIKernelTipOffService';
 export * from './NodeIKernelSearchService';
 export * from './NodeIKernelCollectionService';
+// === New service exports from IDA analysis ===
+export * from './NodeIKernelSettingService';
+export * from './NodeIKernelQiDianService';
+export * from './NodeIKernelSkinService';
+export * from './NodeIKernelQQPlayService';
+export * from './NodeIKernelRDeliveryService';
+export * from './NodeIKernelRemotingService';
+export * from './NodeIKernelLiteBusinessService';
+export * from './NodeIKernelGroupTabService';
+export * from './NodeIKernelLockService';
+export * from './NodeIKernelHandOffService';
+export * from './NodeIKernelMiniAppService';
+export * from './NodeIKernelPublicAccountService';
+export * from './NodeIKernelThirdPartySigService';
+export * from './NodeIKernelUnifySearchService';
+export * from './NodeIKernelVasSystemUpdateService';
+export * from './NodeIKernelPersonalAlbumService';
+export * from './NodeIKernelConfigMgrService';
+export * from './NodeIKernelFeedService';
+export * from './NodeIKernelBdhUploadService';
+export * from './NodeIKernelDirectSessionService';
+export * from './NodeIKernelFileBridgeClientService';
+export * from './NodeIKernelFileBridgeHostService';
+export * from './NodeIKernelWiFiPhotoHostService';
+export * from './NodeIKernelWiFiPhotoClientService';
+export * from './NodeIKernelEmojiService';
+export * from './NodeIKernelNearbyProService';
+export * from './NodeIKernelAVSDKService';
+export * from './NodeIKernelAddBuddyService';
+export * from './NodeIKernelYellowFaceForManagerService';
 
 export type ServiceNamingMapping = {
   NodeIKernelAvatarService: NodeIKernelAvatarService;
@@ -53,6 +83,6 @@ export type ServiceNamingMapping = {
   NodeIKernelRichMediaService: NodeIKernelRichMediaService;
   NodeIKernelDbToolsService: NodeIKernelDbToolsService;
   NodeIKernelTipOffService: NodeIKernelTipOffService;
-  NodeIKernelSearchService: NodeIKernelSearchService,
+  NodeIKernelSearchService: NodeIKernelSearchService;
   NodeIKernelCollectionService: NodeIKernelCollectionService;
 };

--- a/packages/napcat-core/types/msg.ts
+++ b/packages/napcat-core/types/msg.ts
@@ -323,7 +323,7 @@ export interface FlashTransferInfo {
     id: string;
     urls: FlashTransferIcon[];
     localCachePath: string;
-  }
+  };
 }
 
 /**
@@ -337,7 +337,7 @@ export interface MarkdownElement {
   mdExtType?: number;
   mdExtInfo?: {
     flashTransferInfo: FlashTransferInfo;
-  }
+  };
 }
 
 /**
@@ -548,6 +548,96 @@ export interface QueryMsgsParams {
   pageLimit: number;
   isReverseOrder: boolean;
   isIncludeCurrent: boolean;
+}
+
+/**
+ * 消息引用标识（msgId + msgSeq + msgTime）
+ */
+export interface MsgRef {
+  msgId: string;
+  msgSeq: string;
+  msgTime: string;
+}
+
+/**
+ * 消息完整标识（含cliSeq和msgRandom）
+ */
+export interface MsgIdentity {
+  msgId: string;
+  msgSeq: string;
+  cliSeq: string;
+  msgTime: string;
+  msgRandom: string;
+}
+
+/**
+ * 灰条JSON消息信息
+ */
+export interface GrayTipJsonInfo {
+  busiId: number | string;
+  jsonStr: string;
+  recentAbstract: string;
+  isServer: boolean;
+  xmlToJsonParam?: unknown;
+}
+
+/**
+ * 转发文件信息
+ */
+export interface ForwardFileInfo {
+  targetMsgId: string;
+  targetElemId: string;
+  commonFileInfo: unknown;
+}
+
+/**
+ * 本地灰条提示信息
+ */
+export interface LocalGrayTipInfo {
+  type: number;
+  robot?: unknown;
+  direct?: unknown;
+  extraJson: string;
+}
+
+/**
+ * Token设置信息
+ */
+export interface TokenInfo {
+  tokenType: number;
+  apnsToken?: string | Uint8Array;
+  voipToken?: string | Uint8Array;
+  profileId?: string;
+}
+
+/**
+ * 后台切换时的未读计数信息
+ */
+export interface BackGroundInfo {
+  c2cUnreadCnt: number;
+  groupUnreadCnt: number;
+  guildUnreadCnt: number;
+  guildPsvboxUnreadCnt: number;
+  verifyUnreadCnt: number;
+  contactUnreadCnt: number;
+  groupUnreadCodes: string[];
+}
+
+/**
+ * 消息类型过滤参数
+ */
+export interface MsgTypeFilter {
+  filterMsgType: Array<{ type: number; subType: Array<number>; }>;
+  filterSendersUid: string[];
+}
+
+/**
+ * 空间流参数
+ */
+export interface SgrpStreamParams {
+  sgrpStreamPginSourceName: string;
+  sgrpVisitFrom: string;
+  sgrpSessionId: string;
 }
 
 /**

--- a/packages/napcat-core/wrapper.ts
+++ b/packages/napcat-core/wrapper.ts
@@ -29,6 +29,28 @@ import { NodeIkernelTestPerformanceService } from './services/NodeIkernelTestPer
 import { NodeIKernelECDHService } from './services/NodeIKernelECDHService';
 import { NodeIO3MiscService } from './services/NodeIO3MiscService';
 import { NodeIKernelFlashTransferService } from './services/NodeIKernelFlashTransferService';
+import { NodeIKernelOnlineStatusService } from './services/NodeIKernelOnlineStatusService';
+import { NodeIKernelBaseEmojiService } from './services/NodeIKernelBaseEmojiService';
+import { NodeIKernelSettingService } from './services/NodeIKernelSettingService';
+import { NodeIKernelFileAssistantService } from './services/NodeIKernelFileAssistantService';
+import { NodeIKernelDbToolsService } from './services/NodeIKernelDbToolsService';
+import { NodeIYellowFaceService } from './services/NodeIYellowFaceService';
+import { NodeIKernelQiDianService } from './services/NodeIKernelQiDianService';
+import { NodeIKernelSkinService } from './services/NodeIKernelSkinService';
+import { NodeIKernelQQPlayService } from './services/NodeIKernelQQPlayService';
+import { NodeIKernelRDeliveryService } from './services/NodeIKernelRDeliveryService';
+import { NodeIKernelRemotingService } from './services/NodeIKernelRemotingService';
+import { NodeIKernelLiteBusinessService } from './services/NodeIKernelLiteBusinessService';
+import { NodeIKernelGroupTabService } from './services/NodeIKernelGroupTabService';
+import { NodeIKernelLockService } from './services/NodeIKernelLockService';
+import { NodeIKernelHandOffService } from './services/NodeIKernelHandOffService';
+import { NodeIKernelMiniAppService } from './services/NodeIKernelMiniAppService';
+import { NodeIKernelPublicAccountService } from './services/NodeIKernelPublicAccountService';
+import { NodeIKernelThirdPartySigService } from './services/NodeIKernelThirdPartySigService';
+import { NodeIKernelUnifySearchService } from './services/NodeIKernelUnifySearchService';
+import { NodeIKernelVasSystemUpdateService } from './services/NodeIKernelVasSystemUpdateService';
+import { NodeIKernelPersonalAlbumService } from './services/NodeIKernelPersonalAlbumService';
+import { NodeIKernelConfigMgrService } from './services/NodeIKernelConfigMgrService';
 
 export interface NodeQQNTWrapperUtil {
   get (): NodeQQNTWrapperUtil;
@@ -39,45 +61,45 @@ export interface NodeQQNTWrapperUtil {
 
   getSsoCmdOfOidbReq (arg1: number, arg2: number): unknown;
 
-  getSsoBufferOfOidbReq (...args: unknown[]): unknown; // 有点看不懂参数定义 待补充 好像是三个参数
+  getSsoBufferOfOidbReq (arg1: unknown, arg2: unknown, arg3: unknown): unknown;
 
-  getOidbRspInfo (arg: string): unknown; // 可能是错的
+  getOidbRspInfo (arg: string): unknown;
 
-  getFileSize (path: string): Promise<number>; // 直接的猜测
+  getFileSize (path: string): Promise<number>;
 
-  genFileMd5Buf (arg: string): unknown; // 可能是错的
+  genFileMd5Buf (arg: string): unknown;
 
-  genFileMd5Hex (path: string): unknown; // 直接的猜测
+  genFileMd5Hex (path: string): unknown;
 
-  genFileShaBuf (path: string): unknown; // 直接的猜测
+  genFileShaBuf (path: string): unknown;
 
-  genFileCumulateSha1 (path: string): unknown; // 直接的猜测
+  genFileCumulateSha1 (path: string): unknown;
 
-  genFileShaHex (path: string): unknown; // 直接的猜测
+  genFileShaHex (path: string): unknown;
 
   fileIsExist (path: string): unknown;
 
-  startTrace (path: string): unknown; // 可能是错的
+  startTrace (path: string): unknown;
 
   copyFile (src: string, dst: string): unknown;
 
-  genFileShaAndMd5Hex (path: string, unknown: number): unknown; // 可能是错的
+  genFileShaAndMd5Hex (path: string, unknown: number): unknown;
 
   setTraceInfo (unknown: unknown): unknown;
 
   encodeOffLine (unknown: unknown): unknown;
 
-  decodeOffLine (arg: string): unknown; // 可能是错的 传递hex
+  decodeOffLine (arg: string): unknown;
 
-  DecoderRecentInfo (arg: string): unknown; // 可能是错的 传递hex
+  DecoderRecentInfo (arg: string): unknown;
 
   getPinyin (arg0: string, arg1: boolean): unknown;
 
-  matchInPinyin (arg0: unknown[], arg1: string): unknown; // 参数特复杂 arg0是个复杂数据类型
+  getPinyinExt (arg0: string, arg1: boolean): unknown;
+
+  matchInPinyin (arg0: unknown[], arg1: string): unknown;
 
   makeDirByPath (arg0: string): unknown;
-
-  emptyWorkingSet (arg0: number): unknown; // 参数是UINT32
 
   runProcess (arg0: string, arg1: boolean): unknown;
 
@@ -141,6 +163,24 @@ export interface NodeQQNTWrapperUtil {
 
   isNull (): unknown;
 
+  deletePath (path: string): unknown;
+
+  calculateDirectoryTotalSize (path: string): unknown;
+
+  GetBaseEmojiPathByIds (arg: unknown): unknown;
+
+  SetMobileBaseEmojiPath (arg0: unknown, arg1: unknown): unknown;
+
+  setCreateThumbailSupportedFileExtensions (arg0: unknown, arg1: unknown): unknown;
+
+  setFileDropNativeWindowHide (arg: unknown): unknown;
+
+  setFileDropWindowNativeWindowHandle (arg: unknown): unknown;
+
+  startListenFileDragEvent (arg: unknown): unknown;
+
+  stopAccessingSecurityScopedResource (arg: unknown): unknown;
+
   createThumbnailImage (
     serviceName: string,
     filePath: string,
@@ -180,6 +220,43 @@ export interface NodeIQQNTWrapperSession {
 
   startNT (): void;
 
+  // === Session lifecycle ===
+  close (arg: unknown): void;
+
+  onLine (arg: unknown): void;
+
+  offLine (arg: unknown): void;
+
+  disableIpDirect (arg: unknown): void;
+
+  getAccountPath (arg: unknown): string;
+
+  updateTicket (arg: unknown): void;
+
+  // === SSO/Network dispatch ===
+  onDispatchPush (arg1: unknown, arg2: unknown): void;
+
+  onDispatchPushWithJson (arg1: unknown, arg2: unknown): void;
+
+  onDispatchRequestReply (arg1: unknown, arg2: unknown, arg3: unknown): void;
+
+  onMsfPush (arg1: unknown, arg2: unknown, arg3: unknown): void;
+
+  onNetReply (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown): void;
+
+  onSendOidbReply (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown, arg5: unknown): void;
+
+  onSendSSOReply (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown, arg5: unknown): void;
+
+  onUIConfigUpdate (arg1: unknown, arg2: unknown): void;
+
+  setOnMsfStatusChanged (arg1: unknown, arg2: unknown, arg3: unknown): void;
+
+  setOnNetworkChanged (arg: unknown): void;
+
+  setOnWeakNetChanged (arg: unknown): void;
+
+  // === Service getters ===
   getBdhUploadService (): unknown;
 
   getECDHService (): NodeIKernelECDHService;
@@ -220,47 +297,47 @@ export interface NodeIQQNTWrapperSession {
 
   getDirectSessionService (): unknown;
 
-  getRDeliveryService (): unknown;
+  getRDeliveryService (): NodeIKernelRDeliveryService;
 
   getAvatarService (): NodeIKernelAvatarService;
 
   getFeedChannelService (): unknown;
 
-  getYellowFaceService (): unknown;
+  getYellowFaceService (): NodeIYellowFaceService;
 
   getCollectionService (): NodeIKernelCollectionService;
 
-  getSettingService (): unknown;
+  getSettingService (): NodeIKernelSettingService;
 
-  getQiDianService (): unknown;
+  getQiDianService (): NodeIKernelQiDianService;
 
-  getFileAssistantService (): unknown;
+  getFileAssistantService (): NodeIKernelFileAssistantService;
 
   getGuildService (): unknown;
 
-  getSkinService (): unknown;
+  getSkinService (): NodeIKernelSkinService;
 
   getTestPerformanceService (): NodeIkernelTestPerformanceService;
 
-  getQQPlayService (): unknown;
+  getQQPlayService (): NodeIKernelQQPlayService;
 
-  getDbToolsService (): unknown;
+  getDbToolsService (): NodeIKernelDbToolsService;
 
   getUixConvertService (): NodeIKernelUixConvertService;
 
-  getOnlineStatusService (): unknown;
+  getOnlineStatusService (): NodeIKernelOnlineStatusService;
 
-  getRemotingService (): unknown;
+  getRemotingService (): NodeIKernelRemotingService;
 
-  getGroupTabService (): unknown;
+  getGroupTabService (): NodeIKernelGroupTabService;
 
   getGroupSchoolService (): unknown;
 
-  getLiteBusinessService (): unknown;
+  getLiteBusinessService (): NodeIKernelLiteBusinessService;
 
   getGuildMsgService (): unknown;
 
-  getLockService (): unknown;
+  getLockService (): NodeIKernelLockService;
 
   getMSFService (): NodeIKernelMSFService;
 
@@ -270,7 +347,29 @@ export interface NodeIQQNTWrapperSession {
 
   getRecentContactService (): NodeIKernelRecentContactService;
 
-  getConfigMgrService (): unknown;
+  getConfigMgrService (): NodeIKernelConfigMgrService;
+
+  getBaseEmojiService (): NodeIKernelBaseEmojiService;
+
+  getHandOffService (): NodeIKernelHandOffService;
+
+  getMiniAppService (): NodeIKernelMiniAppService;
+
+  getPublicAccountService (): NodeIKernelPublicAccountService;
+
+  getThirdPartySigService (): NodeIKernelThirdPartySigService;
+
+  getUnifySearchService (): NodeIKernelUnifySearchService;
+
+  getVasSystemUpdateService (): NodeIKernelVasSystemUpdateService;
+
+  getPersonalAlbumService (): NodeIKernelPersonalAlbumService;
+
+  getGProGuildMsgService (): unknown;
+
+  getFileBridgeHostService (): unknown;
+
+  getWiFiPhotoClientService (): unknown;
 }
 
 export interface EnginInitDesktopConfig {
@@ -291,6 +390,14 @@ export interface NodeIQQNTWrapperEngine {
   get (): NodeIQQNTWrapperEngine;
 
   initWithDeskTopConfig (config: EnginInitDesktopConfig, nodeIGlobalAdapter: NodeIGlobalAdapter): void;
+
+  initWithMobileConfig (config: unknown, nodeIGlobalAdapter: NodeIGlobalAdapter): void;
+
+  initLog (arg: unknown): void;
+
+  setLogLevel (arg: unknown): void;
+
+  onSendSSOReply (arg1: unknown, arg2: unknown, arg3: unknown, arg4: unknown, arg5: unknown): void;
 }
 
 export interface WrapperNodeApi {


### PR DESCRIPTION
Add multiple NodeIKernel service interface files and tighten up method signatures and types across napcat-core. New interfaces added (e.g. NodeIKernelAVSDKService, NodeIKernelAddBuddyService, NodeIKernelBdhUploadService, NodeIKernelConfigMgrService, NodeIKernelDirectSessionService, NodeIKernelEmojiService, NodeIKernelFeedService, NodeIKernelFileBridgeClientService, NodeIKernelFileBridgeHostService, etc.). Updated existing interfaces with clearer parameter and return types, consistent spacing/semicolons, improved complex return shapes (AlbumService, CollectionService), listener methods, isNull checks, and many other method signature refinements (Avatar, Buddy, DbTools, ECDH, FileAssistant, FlashTransfer, GroupService, and more) to improve type safety and readability.