### PR TITLE
fix: 修复新建网络配置左侧按钮对齐问题

### DIFF
--- a/packages/napcat-webui-frontend/src/components/button/add_button.tsx
+++ b/packages/napcat-webui-frontend/src/components/button/add_button.tsx
@@ -54,7 +54,7 @@ const AddButton: React.FC<AddButtonProps> = (props) => {
           textValue='title'
         >
           <div className='flex items-center gap-2 justify-center'>
-            <div className='w-5 h-5 -ml-3'>
+            <div className='w-5 h-5 -ml-3 flex items-center justify-center'>
               <PlusIcon />
             </div>
             <div className='text-primary-400'>新建网络配置</div>


### PR DESCRIPTION
Before:
<img width="204" height="97" alt="image" src="https://github.com/user-attachments/assets/0436feee-59b0-4c54-b662-17fb48bd3b85" />

After:
<img width="176" height="86" alt="image" src="https://github.com/user-attachments/assets/70623c8a-5d4b-4083-a211-ccc7670b2c1f" />
