### PR TITLE
fix: make album attach_info optional

### DIFF
--- a/packages/napcat-onebot/action/extends/GetGroupAlbumMediaList.ts
+++ b/packages/napcat-onebot/action/extends/GetGroupAlbumMediaList.ts
@@ -5,7 +5,7 @@ import { Static, Type } from '@sinclair/typebox';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   album_id: Type.String({ description: '相册ID' }),
-  attach_info: Type.String({ default: '', description: '附加信息（用于分页）' }),
+  attach_info: Type.Optional(Type.String({ default: '', description: '附加信息（用于分页）' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/extends/GetQunAlbumList.ts
+++ b/packages/napcat-onebot/action/extends/GetQunAlbumList.ts
@@ -4,7 +4,7 @@ import { Static, Type } from '@sinclair/typebox';
 
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
-  attach_info: Type.String({ default: '', description: '附加信息（用于分页，从上一次返回结果中获取）' }),
+  attach_info: Type.Optional(Type.String({ default: '', description: '附加信息（用于分页，从上一次返回结果中获取）' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;


### PR DESCRIPTION
Make attach_info optional for album list actions so OpenAPI no longer marks it as required while preserving the existing default value.