### PR TITLE
fix: 将带默认值的请求字段标记为可选

### DIFF
--- a/packages/napcat-onebot/action/extends/ClickInlineKeyboardButton.ts
+++ b/packages/napcat-onebot/action/extends/ClickInlineKeyboardButton.ts
@@ -5,9 +5,9 @@ import { Static, Type } from '@sinclair/typebox';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   bot_appid: Type.String({ description: '机器人AppID' }),
-  button_id: Type.String({ default: '', description: '按钮ID' }),
-  callback_data: Type.String({ default: '', description: '回调数据' }),
-  msg_seq: Type.String({ default: '10086', description: '消息序列号' }),
+  button_id: Type.Optional(Type.String({ default: '', description: '按钮ID' })),
+  callback_data: Type.Optional(Type.String({ default: '', description: '回调数据' })),
+  msg_seq: Type.Optional(Type.String({ default: '10086', description: '消息序列号' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -34,12 +34,16 @@ export class ClickInlineKeyboardButton extends OneBotAction<PayloadType, ReturnT
   };
 
   async _handle (payload: PayloadType) {
+    const buttonId = payload.button_id ?? '';
+    const callbackData = payload.callback_data ?? '';
+    const msgSeq = payload.msg_seq ?? '10086';
+
     return await this.core.apis.MsgApi.clickInlineKeyboardButton({
-      buttonId: payload.button_id,
+      buttonId,
       peerId: payload.group_id.toString(),
       botAppid: payload.bot_appid,
-      msgSeq: payload.msg_seq,
-      callback_data: payload.callback_data,
+      msgSeq,
+      callback_data: callbackData,
       dmFlag: 0,
       chatType: 2,
     });

--- a/packages/napcat-onebot/action/extends/FetchCustomFace.ts
+++ b/packages/napcat-onebot/action/extends/FetchCustomFace.ts
@@ -3,7 +3,7 @@ import { OneBotAction } from '@/napcat-onebot/action/OneBotAction';
 import { ActionName } from '@/napcat-onebot/action/router';
 
 const PayloadSchema = Type.Object({
-  count: Type.Union([Type.Number(), Type.String()], { default: 48, description: '获取数量' }),
+  count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 48, description: '获取数量' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -27,7 +27,8 @@ export class FetchCustomFace extends OneBotAction<PayloadType, ReturnType> {
   ];
 
   async _handle (payload: PayloadType) {
-    const ret = await this.core.apis.MsgApi.fetchFavEmojiList(+payload.count);
+    const count = payload.count ?? 48;
+    const ret = await this.core.apis.MsgApi.fetchFavEmojiList(+count);
     return ret.emojiInfoList.map(e => e.url);
   }
 }

--- a/packages/napcat-onebot/action/extends/FetchEmojiLike.ts
+++ b/packages/napcat-onebot/action/extends/FetchEmojiLike.ts
@@ -7,8 +7,8 @@ const PayloadSchema = Type.Object({
   message_id: Type.Union([Type.Number(), Type.String()], { description: '消息ID' }),
   emojiId: Type.Union([Type.Number(), Type.String()], { description: '表情ID' }),
   emojiType: Type.Union([Type.Number(), Type.String()], { description: '表情类型' }),
-  count: Type.Union([Type.Number(), Type.String()], { default: 20, description: '获取数量' }),
-  cookie: Type.String({ default: '', description: '分页Cookie' }),
+  count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 20, description: '获取数量' })),
+  cookie: Type.Optional(Type.String({ default: '', description: '分页Cookie' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -59,12 +59,14 @@ export class FetchEmojiLike extends OneBotAction<PayloadType, ReturnType> {
   override returnSchema = ReturnSchema;
 
   async _handle (payload: PayloadType): Promise<ReturnType> {
+    const count = payload.count ?? 20;
+    const cookie = payload.cookie ?? '';
     const msgIdPeer = MessageUnique.getMsgIdAndPeerByShortId(+payload.message_id);
     if (!msgIdPeer) throw new Error('消息不存在');
     const msg = (await this.core.apis.MsgApi.getMsgsByMsgId(msgIdPeer.Peer, [msgIdPeer.MsgId])).msgList[0];
     if (!msg) throw new Error('消息不存在');
     const res = await this.core.apis.MsgApi.getMsgEmojiLikesList(
-      msgIdPeer.Peer, msg.msgSeq, payload.emojiId.toString(), payload.emojiType.toString(), payload.cookie, +payload.count
+      msgIdPeer.Peer, msg.msgSeq, payload.emojiId.toString(), payload.emojiType.toString(), cookie, +count
     );
     return res;
   }

--- a/packages/napcat-onebot/action/extends/GetAiCharacters.ts
+++ b/packages/napcat-onebot/action/extends/GetAiCharacters.ts
@@ -6,7 +6,7 @@ import { ExtendsActionsExamples } from '../example/ExtendsActionsExamples';
 
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
-  chat_type: Type.Union([Type.Number(), Type.String()], { default: 1, description: '聊天类型' }),
+  chat_type: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 1, description: '聊天类型' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/extends/GetCollectionList.ts
+++ b/packages/napcat-onebot/action/extends/GetCollectionList.ts
@@ -4,7 +4,7 @@ import { Type, Static } from '@sinclair/typebox';
 
 const PayloadSchema = Type.Object({
   category: Type.String({ description: '分类ID' }),
-  count: Type.String({ default: '50', description: '获取数量' }),
+  count: Type.Optional(Type.String({ default: '50', description: '获取数量' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -77,6 +77,7 @@ export class GetCollectionList extends OneBotAction<PayloadType, ReturnType> {
   };
 
   async _handle (payload: PayloadType) {
-    return await this.core.apis.CollectionApi.getAllCollection(+payload.category, +payload.count);
+    const count = payload.count ?? '50';
+    return await this.core.apis.CollectionApi.getAllCollection(+payload.category, +count);
   }
 }

--- a/packages/napcat-onebot/action/extends/GetEmojiLikes.ts
+++ b/packages/napcat-onebot/action/extends/GetEmojiLikes.ts
@@ -9,7 +9,7 @@ const PayloadSchema = Type.Object({
   message_id: Type.String({ description: '消息ID，可以传递长ID或短ID' }),
   emoji_id: Type.String({ description: '表情ID' }),
   emoji_type: Type.Optional(Type.String({ description: '表情类型' })),
-  count: Type.Number({ default: 0, description: '数量，0代表全部' }),
+  count: Type.Optional(Type.Number({ default: 0, description: '数量，0代表全部' })),
 });
 type PayloadType = Static<typeof PayloadSchema>;
 
@@ -46,6 +46,7 @@ export class GetEmojiLikes extends OneBotAction<PayloadType, ReturnType> {
   override returnSchema = ReturnSchema;
 
   async _handle (payload: PayloadType) {
+    const count = payload.count ?? 0;
     let peer: Peer;
     let msgId: string;
 
@@ -66,7 +67,7 @@ export class GetEmojiLikes extends OneBotAction<PayloadType, ReturnType> {
     const emojiType = payload.emoji_type ?? (payload.emoji_id.length > 3 ? '2' : '1');
     const emojiLikeList: Array<{ user_id: string; nick_name: string; }> = [];
     let cookie = '';
-    const needFetchCount = payload.count === 0 ? 200 : Math.ceil(payload.count / 15);
+    const needFetchCount = count === 0 ? 200 : Math.ceil(count / 15);
     for (let page = 0; page < needFetchCount; page++) {
       const res = await this.core.apis.MsgApi.getMsgEmojiLikesList(
         peer, msg.msgSeq, payload.emoji_id.toString(), emojiType, cookie, 15
@@ -82,8 +83,8 @@ export class GetEmojiLikes extends OneBotAction<PayloadType, ReturnType> {
       cookie = res.cookie;
     }
     // 切断多余部分
-    if (payload.count > 0) {
-      emojiLikeList.splice(payload.count);
+    if (count > 0) {
+      emojiLikeList.splice(count);
     }
     return { emoji_like_list: emojiLikeList };
   }

--- a/packages/napcat-onebot/action/extends/GetProfileLike.ts
+++ b/packages/napcat-onebot/action/extends/GetProfileLike.ts
@@ -4,8 +4,8 @@ import { Type, Static } from '@sinclair/typebox';
 
 const PayloadSchema = Type.Object({
   user_id: Type.Optional(Type.String({ description: 'QQ号' })),
-  start: Type.Union([Type.Number(), Type.String()], { default: 0, description: '起始位置' }),
-  count: Type.Union([Type.Number(), Type.String()], { default: 10, description: '获取数量' }),
+  start: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 0, description: '起始位置' })),
+  count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 10, description: '获取数量' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -61,10 +61,12 @@ export class GetProfileLike extends OneBotAction<PayloadType, ReturnType> {
   };
 
   async _handle (payload: PayloadType): Promise<ReturnType> {
+    const start = payload.start ?? 0;
+    const count = payload.count ?? 10;
     const isSelf = this.core.selfInfo.uin === payload.user_id || !payload.user_id;
     const userUid = isSelf || !payload.user_id ? this.core.selfInfo.uid : await this.core.apis.UserApi.getUidByUinV2(payload.user_id.toString());
     const type = isSelf ? 2 : 1;
-    const ret = await this.core.apis.UserApi.getProfileLike(userUid ?? this.core.selfInfo.uid, +payload.start, +payload.count, type);
+    const ret = await this.core.apis.UserApi.getProfileLike(userUid ?? this.core.selfInfo.uid, +start, +count, type);
     const data = ret.info.userLikeInfos[0];
     if (!data) {
       throw new Error('get info error');

--- a/packages/napcat-onebot/action/extends/SendPacket.ts
+++ b/packages/napcat-onebot/action/extends/SendPacket.ts
@@ -6,7 +6,7 @@ import { Static, Type } from '@sinclair/typebox';
 const PayloadSchema = Type.Object({
   cmd: Type.String({ description: '命令字' }),
   data: Type.String({ description: '十六进制数据' }),
-  rsp: Type.Union([Type.String(), Type.Boolean()], { default: true, description: '是否等待响应' }),
+  rsp: Type.Optional(Type.Union([Type.String(), Type.Boolean()], { default: true, description: '是否等待响应' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/extends/SetDiyOnlineStatus.ts
+++ b/packages/napcat-onebot/action/extends/SetDiyOnlineStatus.ts
@@ -4,8 +4,8 @@ import { Static, Type } from '@sinclair/typebox';
 
 const PayloadSchema = Type.Object({
   face_id: Type.Union([Type.Number(), Type.String()], { description: '图标ID' }), // 参考 face_config.json 的 QSid
-  face_type: Type.Union([Type.Number(), Type.String()], { default: '1', description: '图标类型' }),
-  wording: Type.String({ default: ' ', description: '状态文字内容' }),
+  face_type: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: '1', description: '图标类型' })),
+  wording: Type.Optional(Type.String({ default: ' ', description: '状态文字内容' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -28,10 +28,12 @@ export class SetDiyOnlineStatus extends OneBotAction<PayloadType, ReturnType> {
 
   override returnExample = '';
   async _handle (payload: PayloadType) {
+    const wording = payload.wording ?? ' ';
+    const faceType = payload.face_type ?? '1';
     const ret = await this.core.apis.UserApi.setDiySelfOnlineStatus(
       payload.face_id.toString(),
-      payload.wording,
-      payload.face_type.toString()
+      wording,
+      faceType.toString()
     );
     if (ret.result !== 0) {
       throw new Error('设置在线状态失败');

--- a/packages/napcat-onebot/action/extends/SetGroupAlbumMediaLike.ts
+++ b/packages/napcat-onebot/action/extends/SetGroupAlbumMediaLike.ts
@@ -7,7 +7,7 @@ const PayloadSchema = Type.Object({
   album_id: Type.String({ description: '相册ID' }),
   lloc: Type.String({ description: '媒体ID (lloc)' }),
   id: Type.String({ description: '点赞ID' }), // 421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|V5bCgAxMDEyOTU5MjU3.PyqaPndPxg!^||^421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|17560363448^||^1
-  set: Type.Boolean({ default: true, description: '是否点赞' }), // true=点赞 false=取消点赞 未实现
+  set: Type.Optional(Type.Boolean({ default: true, description: '是否点赞' })), // true=点赞 false=取消点赞 未实现
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/extends/SetSpecialTitle.ts
+++ b/packages/napcat-onebot/action/extends/SetSpecialTitle.ts
@@ -7,7 +7,7 @@ import { ExtendsActionsExamples } from '../example/ExtendsActionsExamples';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   user_id: Type.String({ description: 'QQ号' }),
-  special_title: Type.String({ default: '', description: '专属头衔' }),
+  special_title: Type.Optional(Type.String({ default: '', description: '专属头衔' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -27,8 +27,9 @@ export class SetSpecialTitle extends GetPacketStatusDepends<PayloadType, ReturnT
   override returnExample = ExtendsActionsExamples.SetSpecialTitle.response;
 
   async _handle (payload: PayloadType) {
+    const specialTitle = payload.special_title ?? '';
     const uid = await this.core.apis.UserApi.getUidByUinV2(payload.user_id.toString());
     if (!uid) throw new Error('User not found');
-    await this.core.apis.PacketApi.pkt.operation.SetGroupSpecialTitle(+payload.group_id, uid, payload.special_title);
+    await this.core.apis.PacketApi.pkt.operation.SetGroupSpecialTitle(+payload.group_id, uid, specialTitle);
   }
 }

--- a/packages/napcat-onebot/action/extends/ShareContact.ts
+++ b/packages/napcat-onebot/action/extends/ShareContact.ts
@@ -5,7 +5,7 @@ import { Static, Type } from '@sinclair/typebox';
 const PayloadSchema = Type.Object({
   user_id: Type.Optional(Type.String({ description: 'QQ号' })),
   group_id: Type.Optional(Type.String({ description: '群号' })),
-  phone_number: Type.String({ default: '', description: '手机号' }),
+  phone_number: Type.Optional(Type.String({ default: '', description: '手机号' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/go-cqhttp/GetFriendMsgHistory.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetFriendMsgHistory.ts
@@ -11,12 +11,12 @@ import { GoCQHTTPActionsExamples } from '../example/GoCQHTTPActionsExamples';
 const PayloadSchema = Type.Object({
   user_id: Type.String({ description: '用户QQ' }),
   message_seq: Type.Optional(Type.String({ description: '起始消息序号' })),
-  count: Type.Number({ default: 20, description: '获取消息数量' }),
-  reverse_order: Type.Boolean({ default: false, description: '是否反向排序' }),
-  disable_get_url: Type.Boolean({ default: false, description: '是否禁用获取URL' }),
-  parse_mult_msg: Type.Boolean({ default: true, description: '是否解析合并消息' }),
-  quick_reply: Type.Boolean({ default: false, description: '是否快速回复' }),
-  reverseOrder: Type.Boolean({ default: false, description: '是否反向排序(旧版本兼容)' }),
+  count: Type.Optional(Type.Number({ default: 20, description: '获取消息数量' })),
+  reverse_order: Type.Optional(Type.Boolean({ default: false, description: '是否反向排序' })),
+  disable_get_url: Type.Optional(Type.Boolean({ default: false, description: '是否禁用获取URL' })),
+  parse_mult_msg: Type.Optional(Type.Boolean({ default: true, description: '是否解析合并消息' })),
+  quick_reply: Type.Optional(Type.Boolean({ default: false, description: '是否快速回复' })),
+  reverseOrder: Type.Optional(Type.Boolean({ default: false, description: '是否反向排序(旧版本兼容)' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -39,6 +39,10 @@ export default class GetFriendMsgHistory extends OneBotAction<PayloadType, Retur
 
   async _handle (payload: PayloadType, _adapter: string, config: NetworkAdapterConfig): Promise<ReturnType> {
     // 处理参数
+    const count = payload.count ?? 20;
+    const reverseOrder = (payload.reverse_order ?? false) || (payload.reverseOrder ?? false);
+    const parseMultMsg = payload.parse_mult_msg ?? true;
+    const disableGetUrl = payload.disable_get_url ?? false;
     const uid = await this.core.apis.UserApi.getUidByUinV2(payload.user_id.toString());
     if (!uid) throw new Error(`记录${payload.user_id}不存在`);
     const friend = await this.core.apis.FriendApi.isBuddy(uid);
@@ -46,8 +50,8 @@ export default class GetFriendMsgHistory extends OneBotAction<PayloadType, Retur
     const hasMessageSeq = !payload.message_seq ? !!payload.message_seq : !(payload.message_seq?.toString() === '' || payload.message_seq?.toString() === '0');
     const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
     const msgList = hasMessageSeq
-      ? (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, payload.reverse_order || payload.reverseOrder)).msgList
-      : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+      ? (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +count, reverseOrder)).msgList
+      : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +count)).msgList;
     if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
     // 转换序号
     await Promise.all(msgList.map(async msg => {
@@ -55,7 +59,7 @@ export default class GetFriendMsgHistory extends OneBotAction<PayloadType, Retur
     }));
     // 烘焙消息
     const ob11MsgList = (await Promise.all(
-      msgList.map(msg => this.obContext.apis.MsgApi.parseMessage(msg, config.messagePostFormat, payload.parse_mult_msg, payload.disable_get_url)))
+      msgList.map(msg => this.obContext.apis.MsgApi.parseMessage(msg, config.messagePostFormat, parseMultMsg, disableGetUrl)))
     ).filter((msg): msg is OB11Message => msg !== undefined);
     return { messages: ob11MsgList };
   }

--- a/packages/napcat-onebot/action/go-cqhttp/GetGroupFilesByFolder.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetGroupFilesByFolder.ts
@@ -8,7 +8,7 @@ const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   folder_id: Type.Optional(Type.String({ description: '文件夹ID' })),
   folder: Type.Optional(Type.String({ description: '文件夹ID' })),
-  file_count: Type.Union([Type.Number(), Type.String()], { default: 50, description: '文件数量' }),
+  file_count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 50, description: '文件数量' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -31,9 +31,10 @@ export class GetGroupFilesByFolder extends OneBotAction<PayloadType, ReturnType>
   override returnExample = GoCQHTTPActionsExamples.GetGroupFilesByFolder.response;
 
   async _handle (payload: PayloadType): Promise<ReturnType> {
+    const fileCount = payload.file_count ?? 50;
     const retRaw = await this.core.apis.MsgApi.getGroupFileList(payload.group_id.toString(), {
       sortType: 1,
-      fileCount: +payload.file_count,
+      fileCount: +fileCount,
       startIndex: 0,
       sortOrder: 2,
       showOnlinedocFolder: 0,

--- a/packages/napcat-onebot/action/go-cqhttp/GetGroupMsgHistory.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetGroupMsgHistory.ts
@@ -10,12 +10,12 @@ import { GoCQHTTPActionsExamples } from '../example/GoCQHTTPActionsExamples';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   message_seq: Type.Optional(Type.String({ description: '起始消息序号' })),
-  count: Type.Number({ default: 20, description: '获取消息数量' }),
-  reverse_order: Type.Boolean({ default: false, description: '是否反向排序' }),
-  disable_get_url: Type.Boolean({ default: false, description: '是否禁用获取URL' }),
-  parse_mult_msg: Type.Boolean({ default: true, description: '是否解析合并消息' }),
-  quick_reply: Type.Boolean({ default: false, description: '是否快速回复' }),
-  reverseOrder: Type.Boolean({ default: false, description: '是否反向排序(旧版本兼容)' }),
+  count: Type.Optional(Type.Number({ default: 20, description: '获取消息数量' })),
+  reverse_order: Type.Optional(Type.Boolean({ default: false, description: '是否反向排序' })),
+  disable_get_url: Type.Optional(Type.Boolean({ default: false, description: '是否禁用获取URL' })),
+  parse_mult_msg: Type.Optional(Type.Boolean({ default: true, description: '是否解析合并消息' })),
+  quick_reply: Type.Optional(Type.Boolean({ default: false, description: '是否快速回复' })),
+  reverseOrder: Type.Optional(Type.Boolean({ default: false, description: '是否反向排序(旧版本兼容)' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -37,13 +37,18 @@ export default class GoCQHTTPGetGroupMsgHistory extends OneBotAction<PayloadType
   override returnExample = GoCQHTTPActionsExamples.GetGroupMsgHistory.response;
 
   async _handle (payload: PayloadType, _adapter: string, config: NetworkAdapterConfig): Promise<ReturnType> {
+    const count = payload.count ?? 20;
+    const reverseOrder = (payload.reverse_order ?? false) || (payload.reverseOrder ?? false);
+    const parseMultMsg = payload.parse_mult_msg ?? true;
+    const disableGetUrl = payload.disable_get_url ?? false;
+    const quickReply = payload.quick_reply ?? false;
     const peer: Peer = { chatType: ChatType.KCHATTYPEGROUP, peerUid: payload.group_id.toString() };
     const hasMessageSeq = !payload.message_seq ? !!payload.message_seq : !(payload.message_seq?.toString() === '' || payload.message_seq?.toString() === '0');
     // 拉取消息
     const startMsgId = hasMessageSeq ? (MessageUnique.getMsgIdAndPeerByShortId(+payload.message_seq!)?.MsgId ?? payload.message_seq!.toString()) : '0';
     const msgList = hasMessageSeq
-      ? (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +payload.count, payload.reverse_order || payload.reverseOrder)).msgList
-      : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +payload.count)).msgList;
+      ? (await this.core.apis.MsgApi.getMsgHistory(peer, startMsgId, +count, reverseOrder)).msgList
+      : (await this.core.apis.MsgApi.getAioFirstViewLatestMsgs(peer, +count)).msgList;
     if (msgList.length === 0) throw new Error(`消息${payload.message_seq}不存在`);
     // 转换序号
     await Promise.all(msgList.map(async msg => {
@@ -51,7 +56,7 @@ export default class GoCQHTTPGetGroupMsgHistory extends OneBotAction<PayloadType
     }));
     // 烘焙消息
     const ob11MsgList = (await Promise.all(
-      msgList.map(msg => this.obContext.apis.MsgApi.parseMessage(msg, config.messagePostFormat, payload.parse_mult_msg, payload.disable_get_url, payload.quick_reply)))
+      msgList.map(msg => this.obContext.apis.MsgApi.parseMessage(msg, config.messagePostFormat, parseMultMsg, disableGetUrl, quickReply)))
     ).filter((msg): msg is OB11Message => msg !== undefined);
     return { messages: ob11MsgList };
   }

--- a/packages/napcat-onebot/action/go-cqhttp/GetGroupRootFiles.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetGroupRootFiles.ts
@@ -6,7 +6,7 @@ import { GoCQHTTPActionsExamples } from '../example/GoCQHTTPActionsExamples';
 
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
-  file_count: Type.Union([Type.Number(), Type.String()], { default: 50, description: '文件数量' }),
+  file_count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 50, description: '文件数量' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -29,9 +29,10 @@ export class GetGroupRootFiles extends OneBotAction<PayloadType, ReturnType> {
   override returnExample = GoCQHTTPActionsExamples.GetGroupRootFiles.response;
 
   async _handle (payload: PayloadType) {
+    const fileCount = payload.file_count ?? 50;
     const ret = await this.core.apis.MsgApi.getGroupFileList(payload.group_id.toString(), {
       sortType: 1,
-      fileCount: +payload.file_count,
+      fileCount: +fileCount,
       startIndex: 0,
       sortOrder: 2,
       showOnlinedocFolder: 0,

--- a/packages/napcat-onebot/action/go-cqhttp/GetStrangerInfo.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetStrangerInfo.ts
@@ -8,7 +8,7 @@ import { GoCQHTTPActionsExamples } from '../example/GoCQHTTPActionsExamples';
 
 const PayloadSchema = Type.Object({
   user_id: Type.String({ description: '用户QQ' }),
-  no_cache: Type.Union([Type.Boolean(), Type.String()], { default: false, description: '是否不使用缓存' }),
+  no_cache: Type.Optional(Type.Union([Type.Boolean(), Type.String()], { default: false, description: '是否不使用缓存' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;

--- a/packages/napcat-onebot/action/go-cqhttp/SendGroupNotice.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/SendGroupNotice.ts
@@ -9,11 +9,11 @@ export const SendGroupNoticePayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   content: Type.String({ description: '公告内容' }),
   image: Type.Optional(Type.String({ description: '公告图片路径或 URL' })),
-  pinned: Type.Union([Type.Number(), Type.String()], { default: 0, description: '是否置顶 (0/1)' }),
-  type: Type.Union([Type.Number(), Type.String()], { default: 1, description: '类型 (默认为 1)' }),
-  confirm_required: Type.Union([Type.Number(), Type.String()], { default: 1, description: '是否需要确认 (0/1)' }),
-  is_show_edit_card: Type.Union([Type.Number(), Type.String()], { default: 0, description: '是否显示修改群名片引导 (0/1)' }),
-  tip_window_type: Type.Union([Type.Number(), Type.String()], { default: 0, description: '弹窗类型 (默认为 0)' }),
+  pinned: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 0, description: '是否置顶 (0/1)' })),
+  type: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 1, description: '类型 (默认为 1)' })),
+  confirm_required: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 1, description: '是否需要确认 (0/1)' })),
+  is_show_edit_card: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 0, description: '是否显示修改群名片引导 (0/1)' })),
+  tip_window_type: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 0, description: '弹窗类型 (默认为 0)' })),
 });
 
 export type SendGroupNoticePayload = Static<typeof SendGroupNoticePayloadSchema>;
@@ -29,6 +29,11 @@ export class SendGroupNotice extends OneBotAction<SendGroupNoticePayload, void> 
   override returnExample = GoCQHTTPActionsExamples.SendGroupNotice.response;
 
   async _handle (payload: SendGroupNoticePayload) {
+    const pinned = payload.pinned ?? 0;
+    const type = payload.type ?? 1;
+    const confirmRequired = payload.confirm_required ?? 1;
+    const showEditCard = payload.is_show_edit_card ?? 0;
+    const tipWindowType = payload.tip_window_type ?? 0;
     let UploadImage: { id: string, width: number, height: number; } | undefined;
     if (payload.image) {
       // 公告图逻辑
@@ -55,11 +60,11 @@ export class SendGroupNotice extends OneBotAction<SendGroupNoticePayload, void> 
     const publishGroupBulletinResult = await this.core.apis.WebApi.setGroupNotice(
       payload.group_id.toString(),
       payload.content,
-      +payload.pinned,
-      +payload.type,
-      +payload.is_show_edit_card,
-      +payload.tip_window_type,
-      +payload.confirm_required,
+      +pinned,
+      +type,
+      +showEditCard,
+      +tipWindowType,
+      +confirmRequired,
       UploadImage?.id,
       UploadImage?.width,
       UploadImage?.height

--- a/packages/napcat-onebot/action/go-cqhttp/UploadGroupFile.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/UploadGroupFile.ts
@@ -13,7 +13,7 @@ export const GoCQHTTPUploadGroupFilePayloadSchema = Type.Object({
   name: Type.String({ description: '文件名' }),
   folder: Type.Optional(Type.String({ description: '父目录 ID' })),
   folder_id: Type.Optional(Type.String({ description: '父目录 ID (兼容性字段)' })), // 临时扩展
-  upload_file: Type.Boolean({ default: true, description: '是否执行上传' }),
+  upload_file: Type.Optional(Type.Boolean({ default: true, description: '是否执行上传' })),
 });
 
 export type GoCQHTTPUploadGroupFilePayload = Static<typeof GoCQHTTPUploadGroupFilePayloadSchema>;

--- a/packages/napcat-onebot/action/go-cqhttp/UploadPrivateFile.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/UploadPrivateFile.ts
@@ -12,7 +12,7 @@ export const GoCQHTTPUploadPrivateFilePayloadSchema = Type.Object({
   user_id: Type.String({ description: '用户 QQ' }),
   file: Type.String({ description: '资源路径或URL' }),
   name: Type.String({ description: '文件名' }),
-  upload_file: Type.Boolean({ default: true, description: '是否执行上传' }),
+  upload_file: Type.Optional(Type.Boolean({ default: true, description: '是否执行上传' })),
 });
 
 export type GoCQHTTPUploadPrivateFilePayload = Static<typeof GoCQHTTPUploadPrivateFilePayloadSchema>;

--- a/packages/napcat-onebot/action/group/SetGroupBan.ts
+++ b/packages/napcat-onebot/action/group/SetGroupBan.ts
@@ -7,7 +7,7 @@ import { GroupActionsExamples } from '../example/GroupActionsExamples';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   user_id: Type.String({ description: '用户QQ' }),
-  duration: Type.Union([Type.Number(), Type.String()], { default: 0, description: '禁言时长(秒)' }),
+  duration: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 0, description: '禁言时长(秒)' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -27,13 +27,14 @@ export default class SetGroupBan extends OneBotAction<PayloadType, ReturnType> {
   override returnExample = GroupActionsExamples.SetGroupBan.response;
 
   async _handle (payload: PayloadType): Promise<null> {
+    const duration = payload.duration ?? 0;
     const uid = await this.core.apis.UserApi.getUidByUinV2(payload.user_id.toString());
     if (!uid) throw new Error('uid error');
     const member_role = (await this.core.apis.GroupApi.getGroupMemberEx(payload.group_id.toString(), uid, true))?.role;
     if (member_role === 4) throw new Error('cannot ban owner');
     // 例如无管理员权限时 result为 120101005 errMsg为 'ERR_NOT_GROUP_ADMIN'
     const ret = await this.core.apis.GroupApi.banMember(payload.group_id.toString(),
-      [{ uid, timeStamp: +payload.duration }]);
+      [{ uid, timeStamp: +duration }]);
     if (ret.result !== 0) throw new Error(ret.errMsg);
     return null;
   }

--- a/packages/napcat-onebot/action/new/GetDoubtFriendsAddRequest.ts
+++ b/packages/napcat-onebot/action/new/GetDoubtFriendsAddRequest.ts
@@ -4,7 +4,7 @@ import { Static, Type } from '@sinclair/typebox';
 import { NewActionsExamples } from '../example/NewActionsExamples';
 
 export const GetDoubtFriendsAddRequestPayloadSchema = Type.Object({
-  count: Type.Number({ default: 50, description: '获取数量' }),
+  count: Type.Optional(Type.Number({ default: 50, description: '获取数量' })),
 });
 
 export type GetDoubtFriendsAddRequestPayload = Static<typeof GetDoubtFriendsAddRequestPayloadSchema>;
@@ -20,6 +20,7 @@ export class GetDoubtFriendsAddRequest extends OneBotAction<GetDoubtFriendsAddRe
   override returnExample = NewActionsExamples.GetDoubtFriendsAddRequest.response;
 
   async _handle (payload: GetDoubtFriendsAddRequestPayload) {
-    return await this.core.apis.FriendApi.getDoubtFriendRequest(payload.count);
+    const count = payload.count ?? 50;
+    return await this.core.apis.FriendApi.getDoubtFriendRequest(count);
   }
 }

--- a/packages/napcat-onebot/action/new/SetDoubtFriendsAddRequest.ts
+++ b/packages/napcat-onebot/action/new/SetDoubtFriendsAddRequest.ts
@@ -5,7 +5,7 @@ import { Static, Type } from '@sinclair/typebox';
 export const SetDoubtFriendsAddRequestPayloadSchema = Type.Object({
   flag: Type.String({ description: '请求 flag' }),
   // 注意强制String 非isNumeric 不遵守则不符合设计
-  approve: Type.Boolean({ default: true, description: '是否同意 (强制为 true)' }),
+  approve: Type.Optional(Type.Boolean({ default: true, description: '是否同意 (强制为 true)' })),
   // 该字段没有语义 仅做保留 强制为True
 });
 

--- a/packages/napcat-onebot/action/stream/UploadFileStream.ts
+++ b/packages/napcat-onebot/action/stream/UploadFileStream.ts
@@ -27,7 +27,7 @@ export const UploadFileStreamPayloadSchema = Type.Object({
   filename: Type.Optional(Type.String({ description: '文件名' })),
   reset: Type.Optional(Type.Boolean({ description: '是否重置' })),
   verify_only: Type.Optional(Type.Boolean({ description: '是否仅验证' })),
-  file_retention: Type.Number({ default: 5 * 60 * 1000, description: '文件保留时间 (毫秒)' }), // 默认5分钟 回收 不设置或0为不回收
+  file_retention: Type.Optional(Type.Number({ default: 5 * 60 * 1000, description: '文件保留时间 (毫秒)' })), // 默认5分钟 回收 不设置或0为不回收
 });
 
 export type UploadFileStreamPayload = Static<typeof UploadFileStreamPayloadSchema>;

--- a/packages/napcat-onebot/action/system/GetSystemMsg.ts
+++ b/packages/napcat-onebot/action/system/GetSystemMsg.ts
@@ -5,7 +5,7 @@ import { Static, Type } from '@sinclair/typebox';
 import { OB11NotifySchema } from '../schemas';
 
 export const GetGroupSystemMsgPayloadSchema = Type.Object({
-  count: Type.Union([Type.Number(), Type.String()], { default: 50, description: '获取的消息数量' }),
+  count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 50, description: '获取的消息数量' })),
 });
 
 export type GetGroupSystemMsgPayload = Static<typeof GetGroupSystemMsgPayloadSchema>;
@@ -36,7 +36,8 @@ export class GetGroupSystemMsg extends OneBotAction<GetGroupSystemMsgPayload, Ge
   };
 
   async _handle (params: GetGroupSystemMsgPayload): Promise<GetGroupSystemMsgReturn> {
-    const SingleScreenNotifies = await this.core.apis.GroupApi.getSingleScreenNotifies(false, +params.count);
+    const count = params.count ?? 50;
+    const SingleScreenNotifies = await this.core.apis.GroupApi.getSingleScreenNotifies(false, +count);
     const retData: GetGroupSystemMsgReturn = { invited_requests: [], InvitedRequest: [], join_requests: [] };
 
     const notifyPromises = SingleScreenNotifies.map(async (SSNotify) => {

--- a/packages/napcat-onebot/action/user/GetRecentContact.ts
+++ b/packages/napcat-onebot/action/user/GetRecentContact.ts
@@ -4,7 +4,7 @@ import { NetworkAdapterConfig } from '@/napcat-onebot/config/config';
 import { Static, Type } from '@sinclair/typebox';
 
 export const GetRecentContactPayloadSchema = Type.Object({
-  count: Type.Union([Type.Number(), Type.String()], { default: 10, description: '获取的数量' }),
+  count: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 10, description: '获取的数量' })),
 });
 
 export type GetRecentContactPayload = Static<typeof GetRecentContactPayloadSchema>;
@@ -45,7 +45,8 @@ export default class GetRecentContact extends OneBotAction<GetRecentContactPaylo
   ];
 
   async _handle (payload: GetRecentContactPayload, _adapter: string, config: NetworkAdapterConfig): Promise<GetRecentContactReturn> {
-    const ret = await this.core.apis.UserApi.getRecentContactListSnapShot(+payload.count);
+    const count = payload.count ?? 10;
+    const ret = await this.core.apis.UserApi.getRecentContactListSnapShot(+count);
     // 烘焙消息
     const results = await Promise.all(ret.info.changedList.map(async (t) => {
       const FastMsg = await this.core.apis.MsgApi.getMsgsByMsgId({ chatType: t.chatType, peerUid: t.peerUid }, [t.msgId]);

--- a/packages/napcat-onebot/action/user/SendLike.ts
+++ b/packages/napcat-onebot/action/user/SendLike.ts
@@ -3,7 +3,7 @@ import { ActionName } from '@/napcat-onebot/action/router';
 import { Static, Type } from '@sinclair/typebox';
 export const SendLikePayloadSchema = Type.Object({
   user_id: Type.String({ description: '对方 QQ 号' }),
-  times: Type.Union([Type.Number(), Type.String()], { default: 1, description: '点赞次数' }),
+  times: Type.Optional(Type.Union([Type.Number(), Type.String()], { default: 1, description: '点赞次数' })),
 });
 
 export type SendLikePayload = Static<typeof SendLikePayloadSchema>;
@@ -26,9 +26,10 @@ export default class SendLike extends OneBotAction<SendLikePayload, void> {
   ];
 
   async _handle (payload: SendLikePayload): Promise<void> {
+    const times = payload.times ?? 1;
     const qq = payload.user_id.toString();
     const uid: string = await this.core.apis.UserApi.getUidByUinV2(qq) ?? '';
-    const result = await this.core.apis.UserApi.like(uid, +payload.times);
+    const result = await this.core.apis.UserApi.like(uid, +times);
     if (result.result !== 0) {
       throw new Error(`点赞失败 ${result.errMsg}`);
     }


### PR DESCRIPTION
## 变更说明

- 将 `napcat-onebot` 中请求 payload 里“有 `default` 但未声明为 `Type.Optional(...)`”的字段统一改为可选，避免 OpenAPI/下游 SDK 将其错误生成为必填参数。
- 在对应 handler 内补充本地默认值归一化，保持运行时行为不变。
- 本次共修正 27 个 action，覆盖历史消息、群公告、群文件、点赞、资料点赞、流式上传等接口。

## 背景

- NapCat 运行时会在校验前通过 `Value.Parse(...)` 填充默认值，因此服务端本身允许省略这类字段。
- 但协议/OpenAPI 层仍会把这些字段标记为 `required`，导致 Python SDK 及其他代码生成客户端把本应可省略的参数视为必填。

## 验证

- `pnpm --filter napcat-onebot run typecheck`
- `pnpm run build:openapi`
- 重新审计生成后的 OpenAPI，请求字段中的 `default + required` 问题已从 47 处降为 0
