### PR TITLE
feat(onebot): 实现发送消息的自适应超时判断，优化长期体验

### DIFF
--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -89,6 +89,8 @@ function keyCanBeParsed (key: string, parser: RawToOb11Converters): key is keyof
 export class OneBotMsgApi {
   obContext: NapCatOneBot11Adapter;
   core: NapCatCore;
+  // 自适应上传带宽预估（字节/秒），初始设为 256KB/s，用于计算图片等大文件的发送超时时间
+  private adaptiveBandwidth = 256 * 1024;
   notifyGroupInvite: LRUCache<string, GroupNotify> = new LRUCache(50);
   // seq -> notify
   rawToOb11Converters: RawToOb11Converters = {
@@ -1270,16 +1272,38 @@ export class OneBotMsgApi {
       return 0;
     });
 
-    const timeout = 10000 + (totalSize / 1024 / 256 * 1000);
+    // 根据当前预估带宽计算预计耗时
+    const estimatedTimeMs = (totalSize / this.adaptiveBandwidth) * 1000;
+    // 最终超时时间 = 基础 10 秒 + 预计耗时（再加 20% 的容错余量）
+    const timeout = 10000 + estimatedTimeMs * 1.2;
+    const startTime = Date.now();
     try {
       const returnMsg = await this.core.apis.MsgApi.sendMsg(peer, sendElements, timeout);
       if (!returnMsg) throw new Error('发送消息失败');
+
+      const elapsed = Date.now() - startTime;
+      // 如果发送成功且耗时超过 1 秒，则根据本次实际表现更新带宽预估
+      if (totalSize > 0 && elapsed > 1000) {
+        const actualSpeed = totalSize / (elapsed / 1000);
+        // 使用平滑加权算法：90% 保留旧数据，10% 采用新数据，避免单次波动影响太大
+        this.adaptiveBandwidth = this.adaptiveBandwidth * 0.9 + actualSpeed * 0.1;
+        // 限制带宽预估范围在 64KB/s 到 2MB/s 之间，防止数值异常
+        this.adaptiveBandwidth = Math.max(64 * 1024, Math.min(this.adaptiveBandwidth, 2 * 1024 * 1024));
+      }
+
       returnMsg.id = MessageUnique.createUniqueMsgId({
         chatType: peer.chatType,
         guildId: '',
         peerUid: peer.peerUid,
       }, returnMsg.msgId);
       return returnMsg;
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message.includes('Timeout')) {
+        // 如果发生超时，说明当前预估太乐观，将带宽预估下调 30%
+        this.adaptiveBandwidth = Math.max(64 * 1024, this.adaptiveBandwidth * 0.7);
+        this.core.context.logger.logWarn(`[OneBot] 消息发送超时，已将预估上传速度调低至: ${Math.round(this.adaptiveBandwidth / 1024)} KB/s`);
+      }
+      throw error;
     } finally {
       cleanTaskQueue.addFiles(deleteAfterSentFiles, timeout);
       // setTimeout(async () => {


### PR DESCRIPTION
为 OneBot 层引入自适应上传带宽预估逻辑，尝试解决在不同网络环境下发送大图、文件等富媒体消息时，因固定超时阈值导致的假性失败问题（在处理 AstrBot 的群分析插件时，频繁出现假超时，出现超时提示但是最后其实完成了发送）。

```
<ActionFailed status='failed', retcode=1200, data=None, message='Timeout: NTEvent serviceAndMethod:NodeIKernelMsgService/sendMsg ListenerName:NodeIKernelMsgListener/onMsgInfoListUpdate EventRet:\n{}\n', wording='Timeout: NTEvent serviceAndMethod:NodeIKernelMsgService/sendMsg ListenerName:NodeIKernelMsgListener/onMsgInfoListUpdate EventRet:\n{}\n', echo={'seq': 22985}, stream='normal-action'>
```

主要变动：
- **自适应预估机制**：在 OneBotMsgApi 中新增 `adaptiveBandwidth` 状态，初始对齐原版 256KB/s。
- **动态超时计算**：超时时间改为 `10s 基础 + (文件大小 / 当前预估带宽) * 1.2`，引入 20% 的动态浮差。
- **实时性能反馈**：
  - 成功发送后，根据实际耗时计算瞬时速率，并以 10% 的加权比例平滑更新预估带宽，实现环境自动对齐。
  - 带宽预估范围严格限制在 64KB/s 至 2MB/s 之间，确保边界安全。
- **超时惩罚逻辑**：一旦发生超时错误，立刻将预估带宽下调 30%，使下一次重试或发送获得更充裕的等待时间。

此方案基于 NapCat 原生设计初衷，旨在提升在恶劣或大幅波动网络环境下的消息发送成功率。