### PR TITLE
fix: enable wss connections and add certificate verification toggle in WebSocket Client

### DIFF
--- a/packages/napcat-onebot/config/config.ts
+++ b/packages/napcat-onebot/config/config.ts
@@ -59,6 +59,7 @@ const WebsocketClientConfigSchema = Type.Object({
   token: Type.String({ default: '' }),
   debug: Type.Boolean({ default: false }),
   heartInterval: Type.Number({ default: 30000 }),
+  verifyCertificate: Type.Optional(Type.Boolean({ default: true })),
 });
 
 const PluginConfigSchema = Type.Object({

--- a/packages/napcat-onebot/network/websocket-client.ts
+++ b/packages/napcat-onebot/network/websocket-client.ts
@@ -73,7 +73,7 @@ export class OB11WebSocketClientAdapter extends IOB11NetworkAdapter<WebsocketCli
     if (!this.connection && this.isEnable) {
       let isClosedByError = false;
 
-      const wsOptions: any = {
+      const wsOptions: WebSocket.ClientOptions = {
         maxPayload: 50 * 1024 * 1024, // 50 MB
         handshakeTimeout: 2000,
         perMessageDeflate: false,

--- a/packages/napcat-onebot/network/websocket-client.ts
+++ b/packages/napcat-onebot/network/websocket-client.ts
@@ -73,7 +73,7 @@ export class OB11WebSocketClientAdapter extends IOB11NetworkAdapter<WebsocketCli
     if (!this.connection && this.isEnable) {
       let isClosedByError = false;
 
-      this.connection = new WebSocket(this.config.url, {
+      const wsOptions: any = {
         maxPayload: 50 * 1024 * 1024, // 50 MB
         handshakeTimeout: 2000,
         perMessageDeflate: false,
@@ -83,8 +83,14 @@ export class OB11WebSocketClientAdapter extends IOB11NetworkAdapter<WebsocketCli
           'x-client-role': 'Universal',  // 为koishi adpter适配
           'User-Agent': 'OneBot/11',
         },
+      };
 
-      });
+      // 如果配置了 verifyCertificate，设置 rejectUnauthorized
+      if (this.config.verifyCertificate !== undefined) {
+        wsOptions.rejectUnauthorized = this.config.verifyCertificate;
+      }
+
+      this.connection = new WebSocket(this.config.url, wsOptions);
       this.connection.on('pong', () => {
         // this.logger.logDebug('[OneBot] [WebSocket Client] 收到pong');
       });

--- a/packages/napcat-protocol/config/config.ts
+++ b/packages/napcat-protocol/config/config.ts
@@ -22,6 +22,7 @@ const WebsocketClientConfigSchema = Type.Object({
   reconnectInterval: Type.Number({ default: 5000 }),
   heartInterval: Type.Number({ default: 30000 }),
   debug: Type.Boolean({ default: false }),
+  verifyCertificate: Type.Optional(Type.Boolean({ default: true })),
 });
 
 // HTTP 服务端配置

--- a/packages/napcat-protocol/config/config.ts
+++ b/packages/napcat-protocol/config/config.ts
@@ -22,7 +22,6 @@ const WebsocketClientConfigSchema = Type.Object({
   reconnectInterval: Type.Number({ default: 5000 }),
   heartInterval: Type.Number({ default: 30000 }),
   debug: Type.Boolean({ default: false }),
-  verifyCertificate: Type.Optional(Type.Boolean({ default: true })),
 });
 
 // HTTP 服务端配置

--- a/packages/napcat-test/schema.test.ts
+++ b/packages/napcat-test/schema.test.ts
@@ -97,6 +97,57 @@ describe('NapCat Configuration Loaders', () => {
     expect(loaded.musicSignUrl).toBe('');
   });
 
+  test('OneBotConfig websocketClients should apply verifyCertificate default', () => {
+    const partialConfig: Partial<OneBotConfig> = {
+      network: {
+        httpServers: [],
+        httpSseServers: [],
+        httpClients: [],
+        websocketServers: [],
+        websocketClients: [{
+          name: 'test-ws-client',
+          enable: true,
+          url: 'wss://example.com',
+          messagePostFormat: 'array',
+          reportSelfMessage: false,
+          reconnectInterval: 5000,
+          token: '',
+          debug: false,
+          heartInterval: 30000,
+        }],
+        plugins: [],
+      },
+    };
+    const loaded = loadOneBotConfig(partialConfig);
+    expect(loaded.network.websocketClients[0]?.verifyCertificate).toBe(true);
+  });
+
+  test('OneBotConfig websocketClients should preserve explicit verifyCertificate false', () => {
+    const partialConfig: Partial<OneBotConfig> = {
+      network: {
+        httpServers: [],
+        httpSseServers: [],
+        httpClients: [],
+        websocketServers: [],
+        websocketClients: [{
+          name: 'test-ws-client',
+          enable: true,
+          url: 'wss://example.com',
+          messagePostFormat: 'array',
+          reportSelfMessage: false,
+          reconnectInterval: 5000,
+          token: '',
+          debug: false,
+          heartInterval: 30000,
+          verifyCertificate: false,
+        }],
+        plugins: [],
+      },
+    };
+    const loaded = loadOneBotConfig(partialConfig);
+    expect(loaded.network.websocketClients[0]?.verifyCertificate).toBe(false);
+  });
+
   test('NapcatConfig should compile and apply defaults', () => {
     let compiled: ReturnType<typeof TypeCompiler.Compile> | undefined;
     expect(() => {

--- a/packages/napcat-webui-frontend/src/components/network_edit/ws_client.tsx
+++ b/packages/napcat-webui-frontend/src/components/network_edit/ws_client.tsx
@@ -2,11 +2,11 @@ import GenericForm, { random_token } from './generic_form';
 import type { Field } from './generic_form';
 
 export interface WebsocketClientFormProps {
-  data?: OneBotConfig['network']['websocketClients'][0]
-  onClose: () => void
+  data?: OneBotConfig['network']['websocketClients'][0];
+  onClose: () => void;
   onSubmit: (
     data: OneBotConfig['network']['websocketClients'][0]
-  ) => Promise<void>
+  ) => Promise<void>;
 }
 
 type WebsocketClientFormType = OneBotConfig['network']['websocketClients'];
@@ -26,6 +26,7 @@ const WebsocketClientForm: React.FC<WebsocketClientFormProps> = ({
     debug: false,
     heartInterval: 30000,
     reconnectInterval: 30000,
+    verifyCertificate: true,
   };
 
   const fields: Field<'websocketClients'>[] = [
@@ -98,6 +99,13 @@ const WebsocketClientForm: React.FC<WebsocketClientFormProps> = ({
       placeholder: '请输入重连间隔',
       isRequired: true,
       colSpan: 1,
+    },
+    {
+      name: 'verifyCertificate',
+      label: 'SSL证书验证',
+      type: 'switch',
+      description: '是否验证SSL证书（wss连接）。关闭后可连接自签名证书的服务器，但会降低安全性',
+      colSpan: 2,
     },
   ];
 

--- a/packages/napcat-webui-frontend/src/types/onebot_conf.d.ts
+++ b/packages/napcat-webui-frontend/src/types/onebot_conf.d.ts
@@ -42,6 +42,7 @@ interface WebsocketClientConfig extends AdapterConfig {
   token: string;
   debug: boolean;
   heartInterval: number;
+  verifyCertificate?: boolean;
 }
 
 interface HttpSseServerConfig extends HttpServerConfig {


### PR DESCRIPTION
fix: enable wss connections and add certificate verification toggle in WebSocket Client

Previous behavior: the WebSocket Client only supported unencrypted ws:// connections; wss:// URLs were not handled and would fail to connect, providing no option to disable TLS certificate validation for development or self-signed certificates.

Fixed behavior: secure WebSocket connections (wss://) are now fully supported. A verifyCertificate configuration option has been introduced, defaulting to true. When set to false, certificate errors (e.g., self-signed certificates) are ignored, enabling safe local testing while maintaining strict validation by default for production.