### PR TITLE
fix(album): refactor group album like payload and implement cancel li…

### DIFF
--- a/packages/napcat-core/apis/webapi.ts
+++ b/packages/napcat-core/apis/webapi.ts
@@ -507,20 +507,36 @@ export class NTQQWebApi {
   async doAlbumMediaLikeByNTQQ (
     qunId: string,
     albumId: string,
-    lloc: string,
-    id: string) {
+    batchId: string,
+    lloc: string | undefined,
+    isLike: boolean
+  ) {
     const random_seq = Math.floor(Math.random() * 9000) + 1000;
     const uin = this.core.selfInfo.uin || '10001';
+
+    const type = isLike ? 2 : 1;
+    const status = isLike ? 0 : 1;
+
+    let id = '';
+    if (lloc) {
+      id = `421_1_0_${qunId}|${albumId}|${batchId}^||^421_1_0_${qunId}|${albumId}|${lloc}^||^0`;
+    } else {
+      id = `421_1_0_${qunId}|${albumId}|${batchId}`;
+    }
+
     return await this.context.session.getAlbumService().doQunLike(
-      random_seq, {
+      random_seq,
+      {
         map_info: [],
         map_bytes_info: [],
         map_user_account: [],
-      }, {
-        id,
-        status: 1,
       },
-      createAlbumFeedPublish(qunId, uin, albumId, lloc)
+      type,
+      {
+        id,
+        status,
+      },
+      createAlbumFeedPublish(qunId, uin, albumId, batchId)
     );
   }
 }

--- a/packages/napcat-core/data/album.ts
+++ b/packages/napcat-core/data/album.ts
@@ -163,14 +163,14 @@ export interface AlbumFeedLikePublish {
   };
   cell_media: {
     album_id: string;
-    batch_id: number;
-    media_items: Array<{
+    batch_id: string | number;
+    media_items?: {
       type: number;
       image: {
         lloc: string;
         sloc: string;
       };
-    }>;
+    }[];
   };
   cell_qun_info: {
     qun_id: string;
@@ -182,21 +182,19 @@ export interface AlbumFeedLikePublish {
  * @param qunId 群号
  * @param uin 用户QQ号
  * @param albumId 相册ID
- * @param lloc 信息
- * @param sloc 信息(可选，默认与lloc相同)
+ * @param batchId 批次ID
  * @returns 动态发布请求参数对象
  */
 export function createAlbumFeedPublish (
   qunId: string,
   uin: string,
   albumId: string,
-  lloc: string,
-  sloc?: string
-): AlbumFeedLikePublish {
+  batchId: string
+) {
   return {
     cell_common: {
       time: Date.now(),
-      feed_id: '',
+      feed_id: `422_0_${batchId}`, // 需要补全feed_id
     },
     cell_user_info: {
       user: {
@@ -205,14 +203,7 @@ export function createAlbumFeedPublish (
     },
     cell_media: {
       album_id: albumId,
-      batch_id: 0,
-      media_items: [{
-        type: 0,
-        image: {
-          lloc,
-          sloc: sloc || lloc,
-        },
-      }],
+      batch_id: batchId,
     },
     cell_qun_info: {
       qun_id: qunId,

--- a/packages/napcat-core/services/NodeIKernelAlbumService.ts
+++ b/packages/napcat-core/services/NodeIKernelAlbumService.ts
@@ -88,6 +88,7 @@ export interface NodeIKernelAlbumService {
       map_bytes_info: unknown[],
       map_user_account: unknown[];
     },
+    type: number,  // type : number  1 取消  2 点赞
     param: {
       // {"id":"421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|V5bCgAxMDEyOTU5MjU3e*KqaLVYdic!^||^421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|17560336594^||^1","status":1}
       id: string,

--- a/packages/napcat-onebot/action/extends/SetGroupAlbumMediaLike.ts
+++ b/packages/napcat-onebot/action/extends/SetGroupAlbumMediaLike.ts
@@ -5,9 +5,8 @@ import { Static, Type } from '@sinclair/typebox';
 const PayloadSchema = Type.Object({
   group_id: Type.String({ description: '群号' }),
   album_id: Type.String({ description: '相册ID' }),
-  lloc: Type.String({ description: '媒体ID (lloc)' }),
-  id: Type.String({ description: '点赞ID' }), // 421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|V5bCgAxMDEyOTU5MjU3.PyqaPndPxg!^||^421_1_0_1012959257|V61Yiali4PELg90bThrH4Bo2iI1M5Kab|17560363448^||^1
-  set: Type.Boolean({ default: true, description: '是否点赞' }), // true=点赞 false=取消点赞 未实现
+  batch_id: Type.String({ description: 'batch_id' }),
+  lloc: Type.Optional(Type.String({ description: 'lloc，若对整个上传操作则不填' })),
 });
 
 type PayloadType = Static<typeof PayloadSchema>;
@@ -22,9 +21,9 @@ export class SetGroupAlbumMediaLike extends OneBotAction<PayloadType, ReturnType
   override actionTags = ['群组扩展'];
   override payloadExample = {
     group_id: '123456',
-    album_id: 'album_id_1',
-    lloc: 'media_id_1',
-    id: '123456',
+    album_id: 'album_id_123',
+    batch_id: '112233',
+    lloc: 'aabbcc12213123',
   };
 
   override returnExample = {
@@ -38,8 +37,38 @@ export class SetGroupAlbumMediaLike extends OneBotAction<PayloadType, ReturnType
     return await this.core.apis.WebApi.doAlbumMediaLikeByNTQQ(
       payload.group_id,
       payload.album_id,
+      payload.batch_id,
       payload.lloc,
-      payload.id
+      true // isLike = true
+    );
+  }
+}
+
+export class CancelGroupAlbumMediaLike extends OneBotAction<PayloadType, ReturnType> {
+  override actionName = ActionName.CancelGroupAlbumMediaLike; // 注意：需要在 router/index.ts 的 ActionName 枚举中补充该定义
+  override actionSummary = '取消点赞群相册媒体';
+  override actionTags = ['群组扩展'];
+  override payloadExample = {
+    group_id: '123456',
+    album_id: 'album_id',
+    batch_id: '112233',
+    lloc: 'aabbcc',
+  };
+
+  override returnExample = {
+    result: {},
+  };
+
+  override payloadSchema = PayloadSchema;
+  override returnSchema = ReturnSchema;
+
+  async _handle (payload: PayloadType) {
+    return await this.core.apis.WebApi.doAlbumMediaLikeByNTQQ(
+      payload.group_id,
+      payload.album_id,
+      payload.batch_id,
+      payload.lloc,
+      false
     );
   }
 }

--- a/packages/napcat-onebot/action/index.ts
+++ b/packages/napcat-onebot/action/index.ts
@@ -134,7 +134,7 @@ import { GetQunAlbumList } from './extends/GetQunAlbumList';
 import { UploadImageToQunAlbum } from './extends/UploadImageToQunAlbum';
 import { DoGroupAlbumComment } from './extends/DoGroupAlbumComment';
 import { GetGroupAlbumMediaList } from './extends/GetGroupAlbumMediaList';
-import { SetGroupAlbumMediaLike } from './extends/SetGroupAlbumMediaLike';
+import { SetGroupAlbumMediaLike, CancelGroupAlbumMediaLike } from './extends/SetGroupAlbumMediaLike';
 import { DelGroupAlbumMedia } from './extends/DelGroupAlbumMedia';
 import { CleanStreamTempFile } from './stream/CleanStreamTempFile';
 import { DownloadFileStream } from './stream/DownloadFileStream';
@@ -169,6 +169,7 @@ export function getAllHandlers (obContext: NapCatOneBot11Adapter, core: NapCatCo
     new UploadFileStream(obContext, core),
     new DelGroupAlbumMedia(obContext, core),
     new SetGroupAlbumMediaLike(obContext, core),
+    new CancelGroupAlbumMediaLike(obContext, core),
     new DoGroupAlbumComment(obContext, core),
     new GetGroupAlbumMediaList(obContext, core),
     new GetQunAlbumList(obContext, core),

--- a/packages/napcat-onebot/action/router.ts
+++ b/packages/napcat-onebot/action/router.ts
@@ -24,6 +24,7 @@ export const ActionName = {
 
   DelGroupAlbumMedia: 'del_group_album_media',
   SetGroupAlbumMediaLike: 'set_group_album_media_like',
+  CancelGroupAlbumMediaLike: 'cancel_group_album_media_like',
   DoGroupAlbumComment: 'do_group_album_comment',
   GetGroupAlbumMediaList: 'get_group_album_media_list',
   UploadImageToQunAlbum: 'upload_image_to_qun_album',


### PR DESCRIPTION
### What does this PR do? / 这个 PR 做了什么？

- Fixed API Payload: Refactored the SetGroupAlbumMediaLike action to match the actual NTQQ protocol. Removed the hardcoded/invalid id parameter.

- Added Missing Parameters: Added the required batch_id and made lloc optional (allowing likes on the entire batch instead of just a single media item). Automatically constructs the complete id and feed_id.

- Fixed API Signature: Passed the missing type parameter (2 for like, 1 for cancel) to doQunLike.

- New Feature: Implemented CancelGroupAlbumMediaLike (cancel_group_album_media_like) to support canceling likes on group album media.

--- 

- 修复 API 载荷： 重构了 SetGroupAlbumMediaLike 动作，使其与真实的 NTQQ 协议抓包对齐。移除了之前要求用户手动传入且容易出错的 id 参数。

- 补充缺失参数： 引入了必要的 batch_id 参数，并将 lloc 设为可选（支持对整个批次点赞或对单图点赞）。现在底层会自动完整构造正确的 id 和 feed_id。

- 修复 API 调用： 为底层的 doQunLike 调用补充了之前缺失的第 3 个参数 type（2 为点赞，1 为取消点赞）。

- 新特性： 新增 CancelGroupAlbumMediaLike (cancel_group_album_media_like) 接口，支持取消点赞群相册媒体。