### PR TITLE
fix: 修复 HTTP Server GET 请求 req.method 大小写比较错误

### DIFF
--- a/packages/napcat-onebot/network/http-server.ts
+++ b/packages/napcat-onebot/network/http-server.ts
@@ -250,7 +250,7 @@ export class OB11HttpServerAdapter extends IOB11NetworkAdapter<HttpServerConfig>
 
   async httpApiRequest (req: Request, res: Response, request_sse: boolean = false) {
     let payload = req.body;
-    if (req.method === 'get') {
+    if (req.method === 'GET') {
       payload = req.query;
     } else if (req.query) {
       payload = { ...req.body, ...req.query };


### PR DESCRIPTION
## 概述
- 修复 `packages/napcat-onebot/network/http-server.ts` 中 `req.method === 'get'` 为 `req.method === 'GET'`
- Express 的 `req.method` 始终返回大写字符串，小写比较永远不会匹配
- 导致 GET 请求走入了错误的 `else if` 分支，而非直接使用 `req.query` 作为 payload

## 详情
在 `httpApiRequest` 方法中，处理 GET 请求时通过 `req.method === 'get'` 判断是否直接使用 `req.query` 作为 payload。但 Express 始终返回大写的 HTTP 方法字符串（`'GET'`、`'POST'` 等），因此该条件永远为 `false`。

GET 请求在大多数情况下碰巧仍能正常工作，因为它会走入 `else if (req.query)` 分支，将空的 `req.body`（`{}`）与 `req.query` 合并。但这并非预期行为，且引入了不必要的对象展开操作。

## 测试计划
- [ ] 发送带 query 参数的 GET 请求到 OneBot HTTP API（如 `GET /get_login_info?access_token=xxx`）
- [ ] 验证参数从 query string 中正确获取
- [ ] 验证 POST 请求仍然正常工作

关闭 #1864