### PR TITLE
fix: 修复 lint 校验失败

### DIFF
--- a/.github/scripts/pr-publish-release.ts
+++ b/.github/scripts/pr-publish-release.ts
@@ -19,7 +19,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
-import { join, basename, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { GitHubAPI, getEnv, setOutput } from './lib/github.ts';
 import { toProxyUrl } from './lib/comment.ts';
 

--- a/packages/napcat-core/helper/ffmpeg/ffmpeg-exec-adapter.ts
+++ b/packages/napcat-core/helper/ffmpeg/ffmpeg-exec-adapter.ts
@@ -138,14 +138,14 @@ export class FFmpegExecAdapter implements IFFmpegAdapter {
   /**
    * 获取时长
    */
-  async getDuration(filePath: string): Promise<number> {
+  async getDuration (filePath: string): Promise<number> {
     const { stdout } = await execFileAsync(this.ffprobePath, [
-      "-v",
-      "error",
-      "-show_entries",
-      "format=duration",
-      "-of",
-      "default=noprint_wrappers=1:nokey=1",
+      '-v',
+      'error',
+      '-show_entries',
+      'format=duration',
+      '-of',
+      'default=noprint_wrappers=1:nokey=1',
       filePath,
     ]);
 

--- a/packages/napcat-onebot/action/packet/BaseGroupTodoAction.ts
+++ b/packages/napcat-onebot/action/packet/BaseGroupTodoAction.ts
@@ -16,7 +16,7 @@ export abstract class BaseGroupTodoAction extends GetPacketStatusDepends<GroupTo
   override returnSchema = Type.Null();
   override actionTags = ['核心接口'];
 
-  protected abstract handleGroupTodo(groupId: number, msgSeq: string): Promise<void>;
+  protected abstract handleGroupTodo (groupId: number, msgSeq: string): Promise<void>;
 
   async _handle (payload: GroupTodoPayload) {
     const groupId = +payload.group_id;

--- a/packages/napcat-test/groupTodoTransformer.test.ts
+++ b/packages/napcat-test/groupTodoTransformer.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test, vi } from 'vitest';
 import { NapProtoMsg } from 'napcat-protobuf';
 import { OidbSvcTrpcTcpBase } from '@/napcat-core/packet/transformer/proto/oidb/OidbBase';
 import { OidbSvcTrpcTcp0XF90 } from '@/napcat-core/packet/transformer/proto/oidb/Oidb.0xf90';
+import SetGroupTodo from '@/napcat-core/packet/transformer/action/SetGroupTodo';
+import CompleteGroupTodo from '@/napcat-core/packet/transformer/action/CompleteGroupTodo';
+import CancelGroupTodo from '@/napcat-core/packet/transformer/action/CancelGroupTodo';
 
 vi.mock('@/napcat-core/packet/transformer/base', () => ({
   PacketTransformer: class PacketTransformer {
@@ -13,10 +16,6 @@ vi.mock('@/napcat-core/packet/transformer/base', () => ({
   },
   PacketBufBuilder: (str: Uint8Array) => Buffer.from(str),
 }));
-
-import SetGroupTodo from '@/napcat-core/packet/transformer/action/SetGroupTodo';
-import CompleteGroupTodo from '@/napcat-core/packet/transformer/action/CompleteGroupTodo';
-import CancelGroupTodo from '@/napcat-core/packet/transformer/action/CancelGroupTodo';
 
 const decodePacket = (data: Buffer) => {
   const base = new NapProtoMsg(OidbSvcTrpcTcpBase).decode(data);

--- a/packages/napcat-webui-frontend/src/pages/dashboard/config/webui.tsx
+++ b/packages/napcat-webui-frontend/src/pages/dashboard/config/webui.tsx
@@ -121,133 +121,135 @@ const WebUIConfigCard = () => {
       <div className='flex flex-col gap-2'>
         <div className='flex-shrink-0 w-full font-bold text-default-600 dark:text-default-400 px-1'>Passkey认证</div>
 
-        {!window.isSecureContext ? (
-          <div className='text-sm text-warning-500 bg-warning-50 p-2 rounded-md border border-warning-200'>
-            ⚠️ 当前处于非安全环境（即既非 HTTPS 也非 localhost），浏览器已禁用 WebAuthn 功能。<br />
-            如果您是通过局域网 IP 访问 WebUI，将无法注册和使用 Passkey。
-          </div>
-        ) : (
-          <>
-            <div className='text-sm text-default-400 mb-2'>
-              注册Passkey后，您可以更便捷地登录WebUI，无需每次输入token
+        {!window.isSecureContext
+          ? (
+            <div className='text-sm text-warning-500 bg-warning-50 p-2 rounded-md border border-warning-200'>
+              ⚠️ 当前处于非安全环境（即既非 HTTPS 也非 localhost），浏览器已禁用 WebAuthn 功能。<br />
+              如果您是通过局域网 IP 访问 WebUI，将无法注册和使用 Passkey。
             </div>
-            <div className='flex gap-2'>
-              <Button
-                color='secondary'
-                variant='flat'
-                onPress={preloadRegistrationOptions}
-                isLoading={isLoadingOptions}
-                className='w-fit'
-              >
-                {!isLoadingOptions}
-                准备选项
-              </Button>
-              <Button
-                color='primary'
-                variant='flat'
-                onPress={() => {
-                  // 必须在用户手势的同步上下文中立即调用WebAuthn API
-                  if (!registrationOptions) {
-                    toast.error('请先点击"准备选项"按钮获取注册选项');
-                    return;
-                  }
-
-                  console.log('开始Passkey注册...');
-                  console.log('使用预先获取的选项:', registrationOptions);
-
-                  if (!navigator.credentials || !navigator.credentials.create) {
-                    toast.error('当前浏览器环境不支持 Passkey 注册。');
-                    return;
-                  }
-
-                  // 立即调用WebAuthn API，不要用async/await
-                  navigator.credentials.create({
-                    publicKey: {
-                      challenge: base64UrlToUint8Array(registrationOptions.challenge) as BufferSource,
-                      rp: {
-                        name: registrationOptions.rp.name,
-                        id: registrationOptions.rp.id,
-                      },
-                      user: {
-                        id: base64UrlToUint8Array(registrationOptions.user.id) as BufferSource,
-                        name: registrationOptions.user.name,
-                        displayName: registrationOptions.user.displayName,
-                      },
-                      pubKeyCredParams: registrationOptions.pubKeyCredParams,
-                      timeout: 30000,
-                      excludeCredentials: registrationOptions.excludeCredentials?.map((cred: any) => ({
-                        id: base64UrlToUint8Array(cred.id) as BufferSource,
-                        type: cred.type,
-                        transports: cred.transports,
-                      })) || [],
-                      attestation: registrationOptions.attestation,
-                    },
-                  }).then(async (credential) => {
-                    console.log('✅ 注册成功！凭据已创建');
-                    console.log('凭据ID:', (credential as PublicKeyCredential).id);
-                    console.log('凭据类型:', (credential as PublicKeyCredential).type);
-
-                    // Prepare response for verification - convert to expected format
-                    const cred = credential as PublicKeyCredential;
-                    const response = {
-                      id: cred.id,  // 保持为base64url字符串
-                      rawId: uint8ArrayToBase64Url(new Uint8Array(cred.rawId)),  // 转换为base64url字符串
-                      response: {
-                        attestationObject: uint8ArrayToBase64Url(new Uint8Array((cred.response as AuthenticatorAttestationResponse).attestationObject)),  // 转换为base64url字符串
-                        clientDataJSON: uint8ArrayToBase64Url(new Uint8Array(cred.response.clientDataJSON)),  // 转换为base64url字符串
-                        transports: (cred.response as AuthenticatorAttestationResponse).getTransports?.() || [],
-                      },
-                      type: cred.type,
-                    };
-
-                    console.log('准备验证响应:', response);
-
-                    try {
-                      // Verify registration
-                      const result = await WebUIManager.verifyPasskeyRegistration(response);
-
-                      if (result.verified) {
-                        toast.success('Passkey注册成功！现在您可以使用Passkey自动登录');
-                        setRegistrationOptions(null); // 清除已使用的选项
-                      } else {
-                        throw new Error('Passkey registration failed');
-                      }
-                    } catch (verifyError) {
-                      console.error('❌ 验证失败:', verifyError);
-                      const err = verifyError as Error;
-                      toast.error(`Passkey验证失败: ${err.message}`);
-                    }
-                  }).catch((error) => {
-                    console.error('❌ 注册失败:', error);
-                    const err = error as Error;
-                    console.error('错误名称:', err.name);
-                    console.error('错误信息:', err.message);
-
-                    // Provide more specific error messages
-                    if (err.name === 'NotAllowedError') {
-                      toast.error('Passkey注册被拒绝。请确保您允许了生物识别认证权限。');
-                    } else if (err.name === 'NotSupportedError') {
-                      toast.error('您的浏览器不支持Passkey功能。');
-                    } else if (err.name === 'SecurityError') {
-                      toast.error('安全错误：请确保使用HTTPS或localhost环境。');
-                    } else {
-                      toast.error(`Passkey注册失败: ${err.message}`);
-                    }
-                  });
-                }}
-                disabled={!registrationOptions}
-                className='w-fit'
-              >
-                注册Passkey
-              </Button>
-            </div>
-            {registrationOptions && (
-              <div className='text-xs text-green-600'>
-                注册选项已准备就绪，可以开始注册
+          )
+          : (
+            <>
+              <div className='text-sm text-default-400 mb-2'>
+                注册Passkey后，您可以更便捷地登录WebUI，无需每次输入token
               </div>
-            )}
-          </>
-        )}
+              <div className='flex gap-2'>
+                <Button
+                  color='secondary'
+                  variant='flat'
+                  onPress={preloadRegistrationOptions}
+                  isLoading={isLoadingOptions}
+                  className='w-fit'
+                >
+                  {!isLoadingOptions}
+                  准备选项
+                </Button>
+                <Button
+                  color='primary'
+                  variant='flat'
+                  onPress={() => {
+                  // 必须在用户手势的同步上下文中立即调用WebAuthn API
+                    if (!registrationOptions) {
+                      toast.error('请先点击"准备选项"按钮获取注册选项');
+                      return;
+                    }
+
+                    console.log('开始Passkey注册...');
+                    console.log('使用预先获取的选项:', registrationOptions);
+
+                    if (!navigator.credentials || !navigator.credentials.create) {
+                      toast.error('当前浏览器环境不支持 Passkey 注册。');
+                      return;
+                    }
+
+                    // 立即调用WebAuthn API，不要用async/await
+                    navigator.credentials.create({
+                      publicKey: {
+                        challenge: base64UrlToUint8Array(registrationOptions.challenge) as BufferSource,
+                        rp: {
+                          name: registrationOptions.rp.name,
+                          id: registrationOptions.rp.id,
+                        },
+                        user: {
+                          id: base64UrlToUint8Array(registrationOptions.user.id) as BufferSource,
+                          name: registrationOptions.user.name,
+                          displayName: registrationOptions.user.displayName,
+                        },
+                        pubKeyCredParams: registrationOptions.pubKeyCredParams,
+                        timeout: 30000,
+                        excludeCredentials: registrationOptions.excludeCredentials?.map((cred: any) => ({
+                          id: base64UrlToUint8Array(cred.id) as BufferSource,
+                          type: cred.type,
+                          transports: cred.transports,
+                        })) || [],
+                        attestation: registrationOptions.attestation,
+                      },
+                    }).then(async (credential) => {
+                      console.log('✅ 注册成功！凭据已创建');
+                      console.log('凭据ID:', (credential as PublicKeyCredential).id);
+                      console.log('凭据类型:', (credential as PublicKeyCredential).type);
+
+                      // Prepare response for verification - convert to expected format
+                      const cred = credential as PublicKeyCredential;
+                      const response = {
+                        id: cred.id,  // 保持为base64url字符串
+                        rawId: uint8ArrayToBase64Url(new Uint8Array(cred.rawId)),  // 转换为base64url字符串
+                        response: {
+                          attestationObject: uint8ArrayToBase64Url(new Uint8Array((cred.response as AuthenticatorAttestationResponse).attestationObject)),  // 转换为base64url字符串
+                          clientDataJSON: uint8ArrayToBase64Url(new Uint8Array(cred.response.clientDataJSON)),  // 转换为base64url字符串
+                          transports: (cred.response as AuthenticatorAttestationResponse).getTransports?.() || [],
+                        },
+                        type: cred.type,
+                      };
+
+                      console.log('准备验证响应:', response);
+
+                      try {
+                      // Verify registration
+                        const result = await WebUIManager.verifyPasskeyRegistration(response);
+
+                        if (result.verified) {
+                          toast.success('Passkey注册成功！现在您可以使用Passkey自动登录');
+                          setRegistrationOptions(null); // 清除已使用的选项
+                        } else {
+                          throw new Error('Passkey registration failed');
+                        }
+                      } catch (verifyError) {
+                        console.error('❌ 验证失败:', verifyError);
+                        const err = verifyError as Error;
+                        toast.error(`Passkey验证失败: ${err.message}`);
+                      }
+                    }).catch((error) => {
+                      console.error('❌ 注册失败:', error);
+                      const err = error as Error;
+                      console.error('错误名称:', err.name);
+                      console.error('错误信息:', err.message);
+
+                      // Provide more specific error messages
+                      if (err.name === 'NotAllowedError') {
+                        toast.error('Passkey注册被拒绝。请确保您允许了生物识别认证权限。');
+                      } else if (err.name === 'NotSupportedError') {
+                        toast.error('您的浏览器不支持Passkey功能。');
+                      } else if (err.name === 'SecurityError') {
+                        toast.error('安全错误：请确保使用HTTPS或localhost环境。');
+                      } else {
+                        toast.error(`Passkey注册失败: ${err.message}`);
+                      }
+                    });
+                  }}
+                  disabled={!registrationOptions}
+                  className='w-fit'
+                >
+                  注册Passkey
+                </Button>
+              </div>
+              {registrationOptions && (
+                <div className='text-xs text-green-600'>
+                  注册选项已准备就绪，可以开始注册
+                </div>
+              )}
+            </>
+          )}
       </div>
       <SaveButtons
         onSubmit={onSubmit}


### PR DESCRIPTION
## 变更内容

- 移除 PR release 脚本中未使用的 `basename` import
- 修复 FFmpeg exec adapter、群待办 action、群待办 transformer 测试和 WebUI passkey 配置页的 ESLint 格式问题
- 调整测试文件的静态 import 顺序，恢复 `import-x/first` 规则通过

## 验证

- `pnpm run lint`
- `pnpm -r --if-present run typecheck`
- `pnpm --filter napcat-test run test`

Closes #1866