### PR TITLE
fix: 校验群名片设置结果

### DIFF
--- a/packages/napcat-onebot/action/group/SetGroupCard.ts
+++ b/packages/napcat-onebot/action/group/SetGroupCard.ts
@@ -1,6 +1,7 @@
 import { OneBotAction } from '@/napcat-onebot/action/OneBotAction';
 import { ActionName } from '@/napcat-onebot/action/router';
 import { Static, Type } from '@sinclair/typebox';
+import { sleep } from '@/napcat-common/src/helper';
 
 import { GroupActionsExamples } from '../example/GroupActionsExamples';
 
@@ -27,8 +28,24 @@ export default class SetGroupCard extends OneBotAction<PayloadType, ReturnType> 
   override returnExample = GroupActionsExamples.SetGroupCard.response;
 
   async _handle (payload: PayloadType): Promise<null> {
-    const member = await this.core.apis.GroupApi.getGroupMember(payload.group_id.toString(), payload.user_id.toString());
-    if (member) await this.core.apis.GroupApi.setMemberCard(payload.group_id.toString(), member.uid, payload.card || '');
-    return null;
+    const groupId = payload.group_id.toString();
+    const userId = payload.user_id.toString();
+    const card = payload.card || '';
+
+    const member = await this.core.apis.GroupApi.getGroupMember(groupId, userId);
+    if (!member) {
+      throw new Error(`群(${groupId})成员${userId}不存在`);
+    }
+
+    await this.core.apis.GroupApi.setMemberCard(groupId, member.uid, card);
+
+    for (let i = 0; i < 3; i++) {
+      await sleep(1000);
+      const updatedMember = await this.core.apis.GroupApi.refreshGroupMemberCachePartial(groupId, member.uid);
+      if (updatedMember?.cardName === card) {
+        return null;
+      }
+    }
+    throw new Error('设置群名片未生效');
   }
 }


### PR DESCRIPTION
## 改动内容

- `set_group_card` 调用底层群名片修改接口后，会重新刷新成员信息并校验结果。
- 如果目标群成员无法解析，直接返回失败。
- 如果刷新后的群名片仍然不是请求设置的值，返回失败，不再返回假成功。

## 修复原因

底层 `modifyMemberCardName` 没有提供可靠的返回结果。之前 OneBot action 只要能找到成员并调用底层接口，就直接返回 `ok`，但 QQ 侧可能并没有真正应用这次修改。

这会导致例如机器人成员、不可修改目标等场景里，接口返回 `ok`，实际群名片却没有变化。

## 验证结果

- `node_modules\.bin\eslint.cmd packages\napcat-onebot\action\group\SetGroupCard.ts`
- `node_modules\.bin\tsc.cmd --noEmit --skipLibCheck -p packages\napcat-onebot\tsconfig.json`
- 在 `packages\napcat-shell` 执行本地构建：`..\..\node_modules\.bin\vite.cmd build`
- 本地 OneBot HTTP 实测：
  - 普通群成员设置群名片返回 `ok`，再次查询确认名片已变更
  - 普通群成员原名片已恢复成功
  - 机器人成员设置群名片返回 `failed`，错误信息为 `设置群名片未生效`
  - 不存在成员返回 `failed`，错误信息为成员不存在
- 本地 OneBot WebSocket 正向连接实测：
  - 普通群成员设置群名片返回 `ok`，再次查询确认名片已变更
  - 普通群成员原名片已恢复成功
  - 机器人成员设置群名片返回 `failed`，错误信息为 `设置群名片未生效`

Closes #1869
