### PR TITLE
fix: reset QQLoginStatus on KickedOffLine to prevent WebUI re-login block

### DIFF
--- a/packages/napcat-framework/napcat.ts
+++ b/packages/napcat-framework/napcat.ts
@@ -195,6 +195,11 @@ export async function NCoreInitFramework (
   if (oneBotAdapter) {
     WebUiDataRuntime.setOneBotContext(oneBotAdapter);
   }
+
+  // 监听下线通知并同步到 WebUI（兜底保障，防止 WebUI 状态不同步）
+  loaderObject.core.event.on('KickedOffLine', () => {
+    WebUiDataRuntime.setQQLoginStatus(false);
+  });
 }
 
 function registerWebUiLoginCallbacks (

--- a/packages/napcat-shell/base.ts
+++ b/packages/napcat-shell/base.ts
@@ -794,6 +794,7 @@ export class NapCatShell {
 
     // 监听下线通知并同步到 WebUI
     this.core.event.on('KickedOffLine', (tips: string) => {
+      WebUiDataRuntime.setQQLoginStatus(false);
       WebUiDataRuntime.setQQLoginError(tips);
     });
     // 使用 NapCatAdapterManager 统一管理协议适配器


### PR DESCRIPTION
## Summary

When QQ kicks the bot offline, the WebUI incorrectly shows the account as still logged in, blocking users from re-login via QR code, quick login, or password login until NapCat is restarted.

## Root Cause

The `KickedOffLine` event handlers in both the shell and framework do not reset `QQLoginStatus`. The QR code endpoint and all other login endpoints check `getQQLoginStatus()` and reject requests with `"QQ Is Logined"` when it remains `true`.

- `napcat-shell/base.ts:796`: Only called `setQQLoginError()` without `setQQLoginStatus(false)`
- `napcat-framework/napcat.ts`: Had no `KickedOffLine` listener at all

## Fix (6 lines)

1. **shell/base.ts**: Added `setQQLoginStatus(false)` before `setQQLoginError(tips)` 
2. **framework/napcat.ts**: Registered a `KickedOffLine` listener on the core event bus

## Related Issues

Fixes #508, Fixes #1818

## Test Plan

1. Log into QQ via NapCat
2. Force kick the account offline (e.g., log in from phone and exit QQ)
3. Navigate to WebUI login page
4. Verify QR code can be generated and refreshed without "QQ Is Logined" error
5. Verify quick login and password login are also accessible