### PR TITLE
fix: get_group_file_system_info 返回真实的 used_space / total_space

### DIFF
--- a/packages/napcat-core/apis/group.ts
+++ b/packages/napcat-core/apis/group.ts
@@ -430,6 +430,24 @@ export class NTQQGroupApi {
     return this.context.session.getRichMediaService().batchGetGroupFileCount(groupCodes);
   }
 
+  // getGroupFileList also carries the group's used/total space in its call
+  // result's `groupSpaceResult`; a single-item fetch is enough to read it.
+  async getGroupFileSpace (groupCode: string) {
+    const [result] = await this.core.eventWrapper.callNormalEventV2(
+      'NodeIKernelRichMediaService/getGroupFileList',
+      'NodeIKernelMsgListener/onGroupFileInfoUpdate',
+      [
+        groupCode,
+        { sortType: 1, fileCount: 1, startIndex: 0, sortOrder: 1, showOnlinedocFolder: 0 },
+      ],
+      () => true,
+      () => true,
+      1,
+      5000
+    );
+    return result?.groupSpaceResult;
+  }
+
   async getArkJsonGroupShare (groupCode: string) {
     const ret = await this.core.eventWrapper.callNoListenerEvent(
       'NodeIKernelGroupService/getGroupRecommendContactArkJson',

--- a/packages/napcat-onebot/action/go-cqhttp/GetGroupFileSystemInfo.ts
+++ b/packages/napcat-onebot/action/go-cqhttp/GetGroupFileSystemInfo.ts
@@ -29,15 +29,22 @@ export class GetGroupFileSystemInfo extends OneBotAction<PayloadType, ReturnType
   override returnExample = GoCQHTTPActionsExamples.GetGroupFileSystemInfo.response;
 
   async _handle (payload: PayloadType) {
-    const groupFileCount = (await this.core.apis.GroupApi.getGroupFileCount([payload.group_id.toString()])).groupFileCounts[0];
-    if (!groupFileCount) {
+    const groupCode = payload.group_id.toString();
+    const [countResult, space] = await Promise.all([
+      this.core.apis.GroupApi.getGroupFileCount([groupCode]),
+      this.core.apis.GroupApi.getGroupFileSpace(groupCode),
+    ]);
+    const groupFileCount = countResult.groupFileCounts[0];
+    if (groupFileCount === undefined) {
       throw new Error('Group not found');
     }
     return {
       file_count: groupFileCount,
       limit_count: 10000,
-      used_space: 0,
-      total_space: 10 * 1024 * 1024 * 1024,
+      // Real values from the kernel's groupSpaceResult; fall back to the old
+      // placeholders if the field is unexpectedly absent.
+      used_space: space?.usedSpace ?? 0,
+      total_space: space?.totalSpace ?? 10 * 1024 * 1024 * 1024,
     };
   }
 }


### PR DESCRIPTION
## 问题

`get_group_file_system_info` 返回的 `used_space` 与 `total_space` 为硬编码占位值（`0` 与 `10 GiB`），未反映群文件系统的实际使用情况。

## 改动

- `NTQQGroupApi` 新增 `getGroupFileSpace`：内核 `getGroupFileList` 的调用结果中本就带有 `groupSpaceResult`（含 `usedSpace` / `totalSpace`），单条拉取即可读到，无需额外接口。
- `get_group_file_system_info` 改为返回上述真实空间；当 `groupSpaceResult` 缺失时回退到原占位值，不产生行为回归。
- 顺带将文件数判空由 `!groupFileCount` 改为 `=== undefined`，避免文件数为 0 的群被误判为 `Group not found`。

`limit_count` 仍保留 `10000`（内核未提供该上限值）。

## 测试

`napcat-core` 与 `napcat-onebot` 两包 `tsc --noEmit --skipLibCheck` 均通过。
