### PR TITLE
fix(onebot): relax packet status check for send poke

### DIFF
--- a/packages/napcat-core/apis/packet.ts
+++ b/packages/napcat-core/apis/packet.ts
@@ -36,7 +36,7 @@ export class NTQQPacketApi {
       })
       .catch((err) => {
         this.logger.logError(err);
-        this.errStack.push(err);
+        this.pushError(err);
         return false;
       })) && this.pkt?.available;
   }
@@ -46,7 +46,15 @@ export class NTQQPacketApi {
   }
 
   get clientLogStack () {
-    return this.pkt?.clientLogStack + '\n' + this.errStack.join('\n');
+    return [this.pkt?.clientLogStack, ...this.errStack].filter(Boolean).join('\n');
+  }
+
+  private pushError (error: unknown) {
+    if (error instanceof Error) {
+      this.errStack.push(error.stack || error.message);
+      return;
+    }
+    this.errStack.push(String(error));
   }
 
   async InitSendPacket (qqVer: string) {
@@ -67,10 +75,17 @@ export class NTQQPacketApi {
     }
     this.pkt = new PacketClientSession(this.core);
     await this.pkt.init(process.pid, table.recv, table.send);
+    if (!this.pkt.available) {
+      const err = '[Core] [Packet] NativePacketClient 初始化失败，PacketBackend 发包能力不可用！';
+      this.logger.logError(err);
+      this.errStack.push(err);
+      return false;
+    }
     try {
       await this.pkt.operation.FetchRkey(3000);
     } catch (error) {
       this.logger.logError('测试Packet状态异常', error);
+      this.pushError(error);
       return false;
     }
     return true;

--- a/packages/napcat-core/packet/client/nativeClient.ts
+++ b/packages/napcat-core/packet/client/nativeClient.ts
@@ -39,12 +39,17 @@ export class NativePacketClient {
 
   async init (_pid: number, recv: string, send: string): Promise<void> {
     const isNewQQ = this.napcore.basicInfo.requireMinNTQQBuild('40824');
-    if (isNewQQ) {
-      const success = this.napi2nativeLoader.initHook(send, recv);
-      if (success) {
-        this.available = true;
-      }
+    if (!isNewQQ) {
+      this.logStack.pushLogWarn('[PacketClient] 当前 QQ 版本低于 NativePacketClient 要求，跳过 Hook 初始化');
+      return;
     }
+    const success = this.napi2nativeLoader.initHook(send, recv);
+    if (success) {
+      this.available = true;
+      this.logStack.pushLogInfo(`[PacketClient] NativePacketClient Hook 初始化成功 platform=${process.platform}.${process.arch}`);
+      return;
+    }
+    this.logStack.pushLogError(`[PacketClient] NativePacketClient Hook 初始化失败 platform=${process.platform}.${process.arch} send=${send} recv=${recv}`);
   }
 
   async sendPacket (

--- a/packages/napcat-onebot/action/packet/GetPacketStatus.ts
+++ b/packages/napcat-onebot/action/packet/GetPacketStatus.ts
@@ -4,6 +4,8 @@ import { Type } from '@sinclair/typebox';
 
 export abstract class GetPacketStatusDepends<PT, RT> extends OneBotAction<PT, RT> {
   protected override async check (payload: PT): Promise<BaseCheckResult> {
+    const schemaResult = await super.check(payload);
+    if (!schemaResult.valid) return schemaResult;
     if (!this.core.apis.PacketApi.packetStatus) {
       return {
         valid: false,
@@ -11,7 +13,22 @@ export abstract class GetPacketStatusDepends<PT, RT> extends OneBotAction<PT, RT
           '错误堆栈信息：' + this.core.apis.PacketApi.clientLogStack,
       };
     }
-    return await super.check(payload);
+    return { valid: true };
+  }
+}
+
+export abstract class PacketSendAvailableDepends<PT, RT> extends OneBotAction<PT, RT> {
+  protected override async check (payload: PT): Promise<BaseCheckResult> {
+    const schemaResult = await super.check(payload);
+    if (!schemaResult.valid) return schemaResult;
+    if (!this.core.apis.PacketApi.available) {
+      return {
+        valid: false,
+        message: 'packetBackend发包能力不可用，请参照文档 https://napneko.github.io/config/advanced 和启动日志检查packetBackend状态或进行配置！' +
+          '错误堆栈信息：' + this.core.apis.PacketApi.clientLogStack,
+      };
+    }
+    return { valid: true };
   }
 }
 

--- a/packages/napcat-onebot/action/packet/SendPoke.ts
+++ b/packages/napcat-onebot/action/packet/SendPoke.ts
@@ -1,5 +1,5 @@
 import { ActionName } from '@/napcat-onebot/action/router';
-import { GetPacketStatusDepends } from '@/napcat-onebot/action/packet/GetPacketStatus';
+import { PacketSendAvailableDepends } from '@/napcat-onebot/action/packet/GetPacketStatus';
 import { Static, Type } from '@sinclair/typebox';
 
 import { PacketActionsExamples } from '../example/PacketActionsExamples';
@@ -11,7 +11,7 @@ export const SendPokePayloadSchema = Type.Object({
 });
 
 export type SendPokePayload = Static<typeof SendPokePayloadSchema>;
-export class SendPokeBase extends GetPacketStatusDepends<SendPokePayload, void> {
+export class SendPokeBase extends PacketSendAvailableDepends<SendPokePayload, void> {
   override payloadSchema = SendPokePayloadSchema;
   override returnSchema = Type.Null();
   override actionSummary = '发送戳一戳';


### PR DESCRIPTION
## Summary

- Split packet send availability from the full PacketBackend status check.
- Make `send_poke`, `group_poke`, and `friend_poke` depend on `PacketApi.available` instead of the stricter `packetStatus` self-test.
- Keep `get_packet_status` and response-dependent packet APIs on the existing full status check.
- Add PacketBackend initialization diagnostics so empty `错误堆栈信息` responses include native hook, unsupported offset, or `FetchRkey` failure details.

## Motivation

`SendPoke` sends an OIDB packet without waiting for a response, but the current OneBot action check requires `packetStatus`, which is only true after the `FetchRkey` request-response self-test succeeds. On macOS this can block `send_poke` with `packetBackend不可用` before the send-only action is attempted, even when the native send hook may already be available.

This change keeps the stricter `packetStatus` semantics for APIs that need response handling, while allowing send-only poke actions to use the lighter native send availability check.

If the native hook itself is unavailable, for example because the current QQ build has no offset entry, `send_poke` will still fail. In that case this change should return a more actionable error stack instead of an empty `错误堆栈信息`.

## Verification

- `pnpm --filter napcat-core run typecheck`
- `pnpm --filter napcat-onebot run typecheck`
- `pnpm build:shell`

I also loaded the locally built `napcat.mjs` on macOS and confirmed the WebUI/OneBot reverse WebSocket startup path. Full real-account poke behavior could not be confirmed on my local QQ hot-update build because PacketBackend offsets were unavailable for that specific build/arch combination.
