### PR TITLE
fix(onebot): 引用回复解析中 quick_reply 形参未解构导致 reply 段丢失

### DIFF
--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -310,9 +310,9 @@ export class OneBotMsgApi {
               peer, msgSeq, msgTime, [senderUid]
             )).msgList;
 
-            const replyMsg = msgRandom
-              ? replyMsgList.find(msg => msg.msgRandom === msgRandom)
-              : replyMsgList.find(msg => msg.msgSeq === msgSeq);
+            const replyMsg = replyMsgList.find(msg =>
+              (msgRandom && msg.msgRandom === msgRandom) || msg.msgSeq === msgSeq
+            );
 
             if (replyMsg) return replyMsg;
             if (quick_reply) {
@@ -327,9 +327,9 @@ export class OneBotMsgApi {
             peer, msgSeq, 1, true, true
           )).msgList;
 
-          const replyMsg = msgRandom
-            ? replyMsgList.find(msg => msg.msgRandom === msgRandom)
-            : replyMsgList.find(msg => msg.msgSeq === msgSeq);
+          const replyMsg = replyMsgList.find(msg =>
+            (msgRandom && msg.msgRandom === msgRandom) || msg.msgSeq === msgSeq
+          );
 
           if (replyMsg) return replyMsg;
 
@@ -341,9 +341,9 @@ export class OneBotMsgApi {
               peer, msgSeq, [senderUid]
             )).msgList;
 
-            const replyMsg = msgRandom
-              ? replyMsgList.find(msg => msg.msgRandom === msgRandom)
-              : replyMsgList.find(msg => msg.msgSeq === msgSeq);
+            const replyMsg = replyMsgList.find(msg =>
+              (msgRandom && msg.msgRandom === msgRandom) || msg.msgSeq === msgSeq
+            );
 
             if (replyMsg) return replyMsg;
 

--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -278,7 +278,7 @@ export class OneBotMsgApi {
       };
     },
 
-    replyElement: async (element, msg, _, quick_reply) => {
+    replyElement: async (element, msg, _, { quick_reply }) => {
       const peer = {
         chatType: msg.chatType,
         peerUid: msg.peerUid,


### PR DESCRIPTION
**问题**
qq机器开发过过程中发现对cq:reply事件渲染错误,和claude排查后发现问题如下:
 群聊中用户正常使用“引用回复”，OneBot 上报的消息里 reply 段丢失，退化为 at + text。
  NapCat 日志（v4.18.8 实测）：
<img width="1280" height="721" alt="bug" src="https://github.com/user-attachments/assets/653a544f-f611-464c-bbea-b878e3168883" />

 **原因**
  1. `parseMessageSegments` 传给各 converter 的第 4 个参数是整个 `RecvMessageContext` 对象（`{ parseMultMsg, disableGetUrl, quick_reply }`），其它 converter 都做了解构，唯独`replyElement` 写成 `async (element, msg, _, quick_reply)` —— `quick_reply` 绑定整个对象、恒为 truthy。于是**所有**引用回复（不只是快速回复场景）只要方法1未匹配就直接`return undefined`，方法2/3 永不执行，最终 reply 段被过滤。
  2. 方法1/2/3 在 `records.msgRandom` 存在时只按 msgRandom 匹配。日志“消息数: 1”说明按seq+时间+发送者已查回目标消息，却因 msgRandom 不一致被丢弃。
  **修复**
  - 解构形参：`async (element, msg, _, { quick_reply })`；
  - 匹配放宽为 msgRandom 优先、msgSeq 精确兜底：
    `find(msg => (msgRandom && msg.msgRandom === msgRandom) || msg.msgSeq === msgSeq)`。

**验证**
  v4.18.8 打补丁后在真实群聊实测：引用近期消息 / 较早消息 / bot 自己发的消息，
  reply 段均恢复上报。
<img width="1280" height="820" alt="fixed" src="https://github.com/user-attachments/assets/b4296db9-2f4c-421c-8c7e-c085c57fee2d" />
