### PR TITLE
fix(onebot): 将显式 group_id 优先级提升至 getTempChatInfo 缓存之前

### DIFF
--- a/packages/napcat-onebot/action/msg/SendMsg.ts
+++ b/packages/napcat-onebot/action/msg/SendMsg.ts
@@ -84,19 +84,19 @@ export async function createContext (core: NapCatCore, payload: OB11PostContext 
     }
     const isBuddy = await core.apis.FriendApi.isBuddy(Uid);
     if (!isBuddy) {
+      if (payload.group_id) {
+        return {
+          chatType: ChatType.KCHATTYPETEMPC2CFROMGROUP,
+          peerUid: Uid,
+          guildId: payload.group_id.toString(),
+        };
+      }
       const ret = await core.apis.MsgApi.getTempChatInfo(ChatType.KCHATTYPETEMPC2CFROMGROUP, Uid);
       if (ret.tmpChatInfo?.groupCode) {
         return {
           chatType: ChatType.KCHATTYPETEMPC2CFROMGROUP,
           peerUid: Uid,
           guildId: '',
-        };
-      }
-      if (payload.group_id) {
-        return {
-          chatType: ChatType.KCHATTYPETEMPC2CFROMGROUP,
-          peerUid: Uid,
-          guildId: payload.group_id.toString(),
         };
       }
       return {


### PR DESCRIPTION
## 问题描述
调用 `send_private_msg` 时，即使显式传入了 `group_id` 参数以指定通过某个群发起临时会话，由于 `createContext()` 中 `getTempChatInfo`（查询旧的临时会话缓存）的优先级高于显式 `group_id`，导致实际使用的仍然是旧缓存所在群，而非调用方指定的群。

当缓存所在群不允许临时会话时（QQ 错误码 103），即使传入的 `group_id` 对应的群已开启临时会话，消息发送仍然失败。

## 原因
`createContext()` 的判断顺序为：
  1. 是好友 → C2C
  2. 不是好友 → `getTempChatInfo` 命中缓存 → 用缓存群
  3. 缓存未命中且传了 `group_id` → 用显式群

第 2 步应该在第 3 步之后：调用方显式指定的 `group_id` 是主动意图，应优先于内部缓存。

## 修复
将 `if (payload.group_id)` 判断移至`getTempChatInfo` 之前，使优先级变为：
  1. 是好友 → C2C
  2. 不是好友且传了 `group_id` → 用显式群
  3. 缓存命中 → 用缓存群

不改变未传入 `group_id` 时的行为。

## 测试

已通过 patch 编译产物 napcat.mjs 在生产环境验证，确认 `group_id` 参数现在可以 正确指定临时会话来源群。