### PR TITLE
feat(qzone): 支持qzone说说删除接口

### DIFF
--- a/packages/napcat-core/apis/webapi.ts
+++ b/packages/napcat-core/apis/webapi.ts
@@ -14,11 +14,14 @@ import { basename } from 'node:path';
 import { qunAlbumControl } from '../data/webapi';
 import { createAlbumCommentRequest, createAlbumFeedPublish, createAlbumMediaFeed } from '../data/album';
 import {
+  buildQzoneDeleteBody,
   buildQzonePublishBody,
   buildQzoneUploadImageBody,
+  parseQzoneDeleteResponse,
   parseQzonePublishResponse,
   parseQzoneUploadImageResponseText,
   toQzoneRichval,
+  QzoneDeleteResponse,
   QzonePublishResponse,
 } from '../data/qzone';
 export interface SetNoticeRetSuccess {
@@ -487,10 +490,10 @@ export class NTQQWebApi {
     const client_key = Date.now() * 1000;
     return await this.context.session.getAlbumService().doQunComment(
       random_seq, {
-        map_info: [],
-        map_bytes_info: [],
-        map_user_account: [],
-      },
+      map_info: [],
+      map_bytes_info: [],
+      map_user_account: [],
+    },
       qunId,
       2,
       createAlbumMediaFeed(uin, albumId, lloc),
@@ -603,6 +606,21 @@ export class NTQQWebApi {
       'Content-Type': 'application/x-www-form-urlencoded',
     }, true, false);
     return parseQzonePublishResponse(result);
+  }
+
+  /**
+   * 删除QQ空间说说
+   * @param tid 说说Tid, 来自 publishQzoneMsg 的返回值
+   */
+  async deleteQzoneMsg (tid: string) {
+    const { uin, g_tk, cookie } = await this.getQzoneAuth();
+    const body = buildQzoneDeleteBody({ hostuin: uin, tid });
+    const api = `https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_delete_v6?g_tk=${g_tk}`;
+    const result = await RequestUtil.HttpGetJson<QzoneDeleteResponse>(api, 'POST', body, {
+      Cookie: cookie,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }, true, false);
+    return parseQzoneDeleteResponse(result);
   }
 
   async getDaySignedList (groupCode: string) {

--- a/packages/napcat-core/data/qzone.ts
+++ b/packages/napcat-core/data/qzone.ts
@@ -157,3 +157,43 @@ export function parseQzonePublishResponse (json: QzonePublishResponse): { tid: s
   }
   return { tid };
 }
+
+export interface QzoneDeleteParams {
+  hostuin: string;
+  tid: string;
+}
+
+/**
+ * 构造删除说说的表单请求体 (application/x-www-form-urlencoded)
+ * 对齐 https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com/cgi-bin/emotion_cgi_delete_v6
+ */
+export function buildQzoneDeleteBody (params: QzoneDeleteParams): string {
+  const { hostuin, tid } = params;
+  const fields: Record<string, string> = {
+    hostuin,
+    tid,
+    t1_source: '1',
+    code_version: '1',
+    format: 'json',
+    qzreferrer: `https://user.qzone.qq.com/${hostuin}`,
+  };
+  return new URLSearchParams(fields).toString();
+}
+
+export interface QzoneDeleteResponse {
+  subcode?: number;
+  code?: number;
+  message?: string;
+  msg?: string;
+}
+
+/**
+ * 解析删除说说接口返回的 JSON
+ */
+export function parseQzoneDeleteResponse (json: QzoneDeleteResponse): { success: true; } {
+  const subcode = json.subcode ?? json.code;
+  if (subcode !== undefined && subcode !== 0) {
+    throw new Error(json.message || json.msg || `QQ空间删说说失败, subcode=${subcode}`);
+  }
+  return { success: true };
+}

--- a/packages/napcat-onebot/action/example/ExtendsActionsExamples.ts
+++ b/packages/napcat-onebot/action/example/ExtendsActionsExamples.ts
@@ -46,4 +46,8 @@ export const ExtendsActionsExamples = {
     payload: { content: '今天天气不错', images: [], ugc_right: 1, target_uins: [] },
     response: { tid: '1234567890abcdef1234567890' },
   },
+  DeleteQzoneMsg: {
+    payload: { tid: '1234567890abcdef1234567890' },
+    response: null,
+  },
 };

--- a/packages/napcat-onebot/action/extends/DeleteQzoneMsg.ts
+++ b/packages/napcat-onebot/action/extends/DeleteQzoneMsg.ts
@@ -1,0 +1,26 @@
+import { OneBotAction } from '@/napcat-onebot/action/OneBotAction';
+import { ActionName } from '@/napcat-onebot/action/router';
+import { Static, Type } from '@sinclair/typebox';
+import { ExtendsActionsExamples } from '../example/ExtendsActionsExamples';
+
+const PayloadSchema = Type.Object({
+  tid: Type.String({ description: '说说 tid (来自 get_qzone_msg_list / send_qzone_msg)' }),
+});
+
+type PayloadType = Static<typeof PayloadSchema>;
+
+export class DeleteQzoneMsg extends OneBotAction<PayloadType, void> {
+  override actionName = ActionName.DeleteQzoneMsg;
+  override actionSummary = '删除QQ空间说说';
+  override actionDescription = '删除QQ空间(Qzone)的一条说说, 按 tid 删除';
+  override actionTags = ['扩展接口'];
+  override payloadExample = ExtendsActionsExamples.DeleteQzoneMsg.payload;
+  override returnExample = ExtendsActionsExamples.DeleteQzoneMsg.response;
+
+  override payloadSchema = PayloadSchema;
+  override returnSchema = Type.Null();
+
+  async _handle (payload: PayloadType): Promise<void> {
+    await this.core.apis.WebApi.deleteQzoneMsg(payload.tid);
+  }
+}

--- a/packages/napcat-onebot/action/index.ts
+++ b/packages/napcat-onebot/action/index.ts
@@ -161,6 +161,7 @@ import { GetFilesetId } from './file/flash/GetFilesetIdByCode';
 import { FetchPttText } from '@/napcat-onebot/action/msg/FetchPttText';
 import { GetGroupSignedList } from './extends/GetGroupSignedList';
 import { SendQzoneMsg } from './extends/SendQzoneMsg';
+import { DeleteQzoneMsg } from './extends/DeleteQzoneMsg';
 
 export function getAllHandlers (obContext: NapCatOneBot11Adapter, core: NapCatCore) {
   const actionHandlers = [
@@ -218,6 +219,7 @@ export function getAllHandlers (obContext: NapCatOneBot11Adapter, core: NapCatCo
     new TransGroupFile(obContext, core),
     new GetGroupSignedList(obContext, core),
     new SendQzoneMsg(obContext, core),
+    new DeleteQzoneMsg(obContext, core),
     // onebot11
     new SendLike(obContext, core),
     new GetMsg(obContext, core),

--- a/packages/napcat-onebot/action/router.ts
+++ b/packages/napcat-onebot/action/router.ts
@@ -217,4 +217,5 @@ export const ActionName = {
 
   // QQ 空间扩展
   SendQzoneMsg: 'send_qzone_msg',
+  DeleteQzoneMsg: 'delete_qzone_msg',
 } as const;

--- a/packages/napcat-test/qzone.test.ts
+++ b/packages/napcat-test/qzone.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import {
+  buildQzoneDeleteBody,
   buildQzonePublishBody,
   buildQzoneUploadImageBody,
+  parseQzoneDeleteResponse,
   parseQzonePublishResponse,
   parseQzoneUploadImageResponseText,
   toQzoneRichval,
@@ -90,5 +92,29 @@ describe('Qzone data helpers', () => {
 
   test('parseQzonePublishResponse throws when tid missing', () => {
     expect(() => parseQzonePublishResponse({ subcode: 0 })).toThrow();
+  });
+
+  test('buildQzoneDeleteBody encodes required fields', () => {
+    const body = buildQzoneDeleteBody({ hostuin: '123456', tid: 'tid123' });
+    const params = new URLSearchParams(body);
+    expect(params.get('hostuin')).toBe('123456');
+    expect(params.get('tid')).toBe('tid123');
+    expect(params.get('t1_source')).toBe('1');
+    expect(params.get('code_version')).toBe('1');
+    expect(params.get('format')).toBe('json');
+    expect(params.get('qzreferrer')).toContain('123456');
+  });
+
+  test('parseQzoneDeleteResponse succeeds when subcode is 0', () => {
+    const result = parseQzoneDeleteResponse({ subcode: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  test('parseQzoneDeleteResponse throws when subcode indicates failure', () => {
+    expect(() => parseQzoneDeleteResponse({ subcode: -200, message: '权限不足' })).toThrow('权限不足');
+  });
+
+  test('parseQzoneDeleteResponse throws with default message when subcode indicates failure without message', () => {
+    expect(() => parseQzoneDeleteResponse({ subcode: -200 })).toThrow('subcode=-200');
   });
 });


### PR DESCRIPTION
## 功能描述
实现了删除QQ空间说说的接口
新增`/delete_qzone_msg`端点，与SnowLuma相关接口对齐，行为一致
https://snowluma.github.io/api/qzone/delete_qzone_msg.html

## 改动
- qzone.ts
  - 新增 buildQzoneDeleteBody/parseQzoneDeleteResponse 纯函数
- webapi.ts
  - 新增 deleteQzoneMsg(tid)，复用现有 getQzoneAuth()，POST 到 emotion_cgi_delete_v6
- DeleteQzoneMsg.ts（新建）
  - OneBot 动作，payload 仅 tid，返回 null
  - router.ts / index.ts / ExtendsActionsExamples.ts：注册新动作和示例
- qzone.test.ts
  - 新增 4 个单元测试

## 测试
- [x] napcat-test 测试通过
- [x] napcat-core、napcat-onebot 等相关包 typecheck 全部通过
- [x] ESLint 检查通过
- [x] 已真机QQ实测，删除说说能正常生效，tid错误时能正常返回报错，onebot返回status正常

