### PR TITLE
fix: 修复 WebUI 白屏与 arm64/proot 下 Worker SIGSEGV

### DIFF
--- a/packages/napcat-shell/napcat.ts
+++ b/packages/napcat-shell/napcat.ts
@@ -247,6 +247,7 @@ async function startWorker (passQuickLogin: boolean = true, secretKey?: string, 
       ...(preferredPort ? { NAPCAT_WEBUI_PREFERRED_PORT: String(preferredPort) } : {}),
     },
     stdio: isElectron ? 'pipe' : ['inherit', 'pipe', 'pipe', 'ipc'],
+    ...(!isElectron ? { execArgv: ['--no-sandbox'] } : {}),
   });
 
   currentWorker = child;

--- a/packages/napcat-shell/process-api.ts
+++ b/packages/napcat-shell/process-api.ts
@@ -34,6 +34,7 @@ export interface IWorkerProcess {
 export interface ProcessOptions {
   env: NodeJS.ProcessEnv;
   stdio: 'pipe' | 'ignore' | 'inherit' | Array<'pipe' | 'ignore' | 'inherit' | 'ipc'>;
+  execArgv?: string[];
 }
 
 /**
@@ -168,7 +169,7 @@ export async function createProcessManager (): Promise<{
   manager: IProcessManager;
   isElectron: boolean;
 }> {
-  const isElectron = typeof process.versions['electron'] !== 'undefined';
+  const isElectron = process.env['NAPCAT_FORCE_NODE_PROCESS'] !== '1' && typeof process.versions['electron'] !== 'undefined';
 
   if (isElectron) {
     // @ts-ignore - electron 运行时存在但类型声明可能缺失

--- a/packages/napcat-webui-frontend/vite.config.ts
+++ b/packages/napcat-webui-frontend/vite.config.ts
@@ -44,8 +44,11 @@ export default defineConfig(({ mode }) => {
               // if (id.includes('@heroui/')) {
               //   return 'heroui';
               // }
-              if (id.includes('react-dom')) {
-                return 'react-dom';
+              // React 19: react / react-dom / scheduler 必须合并到同一 vendor chunk，
+              // 否则 react 的 forwardRef 等 API 会被错导向 react-dom 块而变成 undefined，
+              // 导致 codemirror-core 等 chunk 初始化即崩溃（Cannot read properties of undefined (reading 'forwardRef')）。
+              if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+                return 'react-vendor';
               }
               if (id.includes('react-router-dom')) {
                 return 'react-router-dom';


### PR DESCRIPTION
## 修复内容

### 1. WebUI 白屏（b1b82c1d）
React 19 + Vite `manualChunks` 将 `react` / `react-dom` / `scheduler` 拆到不同 chunk，导致 `codemirror-core` 从 `react-dom` chunk 取 `forwardRef` 得到 `undefined`，初始化即崩溃（`Cannot read properties of undefined (reading 'forwardRef')`），WebUI 整页白屏。
改为把 `react` / `react-dom` / `scheduler` 合并为单一 `react-vendor` chunk。

### 2. arm64 / proot 下 Worker SIGSEGV（fa352b59）
Electron `UtilityProcess` 在 arm64 / proot 环境下崩溃（退出码 11），导致 NapCat 主进程退出、WebUI 关闭。
- `process-api.ts`：`ProcessOptions` 增加 `execArgv` 选项；`isElectron` 增加 `NAPCAT_FORCE_NODE_PROCESS` 环境变量判断，可强制走 Node 进程管理器。
- `napcat.ts`：Node 进程路径下为 Worker 注入 `execArgv: ['--no-sandbox']`。
设置 `NAPCAT_FORCE_NODE_PROCESS=1` 即可绕过 Electron `UtilityProcess`，改用 `child_process.fork`。

## 说明
原 Worker 修复 commit 同时修改了 `scripts/install.sh`（基于 [install.sh](https://github.com/NapNeko/NapCat-Installer/blob/main/script/install.sh) , Launcher 注入，Root/Rootless，修复 QQ CDN IPv6 连接问题 的安装脚本），该文件为 fork 附加改进，已排除；本 PR 仅含 `napcat-shell` 源码修复。
