### PR TITLE
fix: 私聊引用消息 reply 段丢失，records 命中时直接用 msgId 构造并携带被引用文本

### DIFF
--- a/packages/napcat-core/types/element.ts
+++ b/packages/napcat-core/types/element.ts
@@ -235,8 +235,16 @@ export interface StructLongMsgElement {
   resId: string;
 }
 
+export interface ReplyTextElem {
+  replyAbsElemType?: number;
+  textElemContent?: string;
+  faceElem?: unknown;
+  picElem?: unknown;
+}
+
 export interface ReplyElement {
   sourceMsgIdInRecords?: string;
+  sourceMsgTextElems?: ReplyTextElem[];
   replayMsgSeq: string;
   replayMsgId: string;
   senderUin: string;

--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -287,19 +287,27 @@ export class OneBotMsgApi {
       };
 
       // 创建回复数据的通用方法
-      const createReplyData = (msgId: string): OB11MessageData => ({
+      const createReplyData = (msgId: string, text?: string): OB11MessageData => ({
         type: OB11MessageDataType.reply,
         data: {
           id: MessageUnique.createUniqueMsgId(peer, msgId).toString(),
+          ...(text ? { text } : {}),
         },
       });
 
       // 查找记录
       const records = msg.records.find(msgRecord => msgRecord.msgId === element?.sourceMsgIdInRecords);
 
-      // 特定账号的特殊处理
-      if (records && (records.peerUin === '284840486' || records.peerUin === '1094950020')) {
-        return createReplyData(records.msgId);
+      // 记录命中时直接用记录中的 msgId 构造 reply 段。
+      // 原实现只对特定账号（开发者测试号）走此捷径，其余账号走下方 seq 查询链；
+      // 但私聊中引用消息的 replayMsgSeq 常被解析为 0（引用 bot 或自己发的消息时尤甚），
+      // 查询链必然全部失败 → reply 段被静默丢弃（参见 #1508）。
+      // records.msgId 即被引用消息的真实 msgId，直接使用无需再查询。
+      if (records && records.msgId && records.msgId !== '0') {
+        const quotedText = (element?.sourceMsgTextElems || [])
+          .map(el => el.textElemContent ?? '')
+          .join('');
+        return createReplyData(records.msgId, quotedText);
       }
 
       // 获取消息的通用方法组

--- a/packages/napcat-onebot/types/message.ts
+++ b/packages/napcat-onebot/types/message.ts
@@ -71,6 +71,7 @@ export const OB11MessageReplySchema = Type.Object({
   data: Type.Object({
     id: Type.Optional(Type.String({ description: '消息ID的短ID映射' })),
     seq: Type.Optional(Type.Number({ description: '消息序列号，优先使用' })),
+    text: Type.Optional(Type.String({ description: '被引用消息文本（记录命中时直接携带，避免二次查询）' })),
   }),
 }, { $id: 'OB11MessageReply', description: '回复消息段' });
 


### PR DESCRIPTION
## 问题描述

私聊中引用（回复）消息时，OneBot 事件里**丢失 reply 段**——`message` 数组只剩 text 段，下游框架收不到引用信息（如 `reply_to_id=None`）。群聊不受影响。

## 复现步骤

1. BOT 账号（或任意账号）在私聊发一条消息
2. 对方引用该消息并发送（带或不带文字均可）
3. 查看 OneBot 事件：`message` 数组中没有 `{"type":"reply",...}` 段，`raw_message` 也只剩纯文本

## 根因分析

引用消息的原始 `replyElement` 中，`replayMsgSeq` 被解析为 `"0"`（引用 bot 或自己发的消息时尤甚，`peerUin` 同样为 0），而 `replyElement` 的转换逻辑依赖 `replayMsgSeq` 走三种查询方法 + 协议兜底：

```
方法1查询失败，序号: 0, 消息数: 1
方法2查询失败，序号: 0, 消息数: 0
方法3查询失败，序号: 0, 消息数: 1
所有查找方法均失败，获取不到带记录的引用消息 0
协议兜底未找到匹配的引用消息
```

全部失败后 `return null`，reply 段被**静默丢弃**。

但同一事件的 `records[]` 与 `sourceMsgIdInRecords` 字段携带了被引用消息的**完整记录**（真实 msgId、发送者、时间、文本内容）。现有代码只在 `records.peerUin` 属于两个特定账号（`284840486`/`1094950020`）时才直接用 `records.msgId` 构造 reply 段——其他账号走必然失败的 seq 查询链。

相关 issue：#1508（BOT发起的私聊消息被引用回复时获取不到引用消息）、#477（私聊引用丢 reply 段）。

## 修复方案

records 命中（`msgId === sourceMsgIdInRecords`）且 msgId 有效时，**直接用 `records.msgId` 构造 reply 段**，不再依赖 seq 查询；同时从 `sourceMsgTextElems` 提取被引用文本，作为可选 `text` 字段携带（下游可直接使用，无需二次查询——NapCat 的 `get_msg` 对 bot 消息等场景同样会查不到）。

- `replyElement`：把「特定账号捷径」推广为「records 命中即直用」（`records.msgId` 即被引用消息的真实 msgId，查询链本就多余）
- `createReplyData`：新增可选 `text` 参数
- `OB11MessageReplySchema`：data 新增可选 `text` 字段（向后兼容，不改变现有字段语义）

## 测试结果

- 环境：NapCat docker（2026-08 镜像）+ 私聊引用 bot 消息
- 修复前：100% 丢 reply 段（连续 51 次「所有查找方法均失败」日志）
- 修复后：`message` 数组正确输出 `{"type":"reply","data":{"id":"<shortId>","text":"<被引用文本>"}}`，下游 `reply_to_id`/`reply_to_text` 均正常

## 兼容性

- `text` 为 Optional 新字段，不发送时行为与原来完全一致
- 原 seq 查询链保留（records 未命中时仍走原逻辑）
- 群聊引用路径不变（同样受益于 records 直用，行为一致）
