### PR TITLE
更换音乐卡片签名api，但也保留原来的

### DIFF
--- a/packages/napcat-onebot/api/msg.ts
+++ b/packages/napcat-onebot/api/msg.ts
@@ -860,12 +860,23 @@ export class OneBotMsgApi {
       // 获取签名服务地址
       let signUrl = this.obContext.configLoader.configData.musicSignUrl;
       if (!signUrl) {
-        signUrl = 'https://ss.xingzhige.com/music_card/card';// 感谢思思！已获思思许可 其余地方使用请自行询问
+        signUrl = 'https://qqbotark.569879.xyz/'; //首选,yibai音卡签名
       }
 
       // 请求签名服务
       try {
-        const musicJson = await RequestUtil.HttpGetJson<string>(signUrl, 'POST', postData);
+        let musicJson: string;
+        try {
+          musicJson = await RequestUtil.HttpGetJson<string>(signUrl, 'POST', postData);
+        } catch {
+          // 首选失败，降级到备选
+          this.core.context.logger.logError('[音乐卡片签名] 首选地址失败，尝试备选地址...');
+          musicJson = await RequestUtil.HttpGetJson<string>(
+            'https://ss.xingzhige.com/music_card/card', //思思的音卡签名
+            'POST',
+            postData
+          );
+        }
         return this.ob11ToRawConverters.json({
           data: { data: musicJson },
           type: OB11MessageDataType.json,


### PR DESCRIPTION
由于思思的音卡签名可能出现问题，测试时已无法使用，特此自建签名api并替换。同时加入备选思思api逻辑