### PR TITLE
fix: 修复账号被踢下线后，"刷新二维码"功能无效的问题

### DIFF
--- a/packages/napcat-framework/napcat.ts
+++ b/packages/napcat-framework/napcat.ts
@@ -105,6 +105,13 @@ export async function NCoreInitFramework (
       loginContext.isLogined = true;
       WebUiDataRuntime.setQQLoginStatus(true);
       WebUiDataRuntime.setQQLoginError('');
+      const oneBotContext = WebUiDataRuntime.getOneBotContext();
+      if (oneBotContext?.core?.selfInfo) {
+        oneBotContext.core.selfInfo.online = true;
+        WebUiDataRuntime.setQQLoginPhase('ready');
+      } else {
+        WebUiDataRuntime.setQQLoginPhase('initializing');
+      }
       await new Promise<void>(resolve => {
         registerInitCallback(() => resolve());
       });
@@ -118,6 +125,8 @@ export async function NCoreInitFramework (
 
     loginListener.onQRCodeGetPicture = ({ qrcodeUrl }) => {
       WebUiDataRuntime.setQQLoginQrcodeURL(qrcodeUrl);
+      WebUiDataRuntime.setQQLoginError('');
+      WebUiDataRuntime.setQQLoginPhase('waiting_qrcode');
       logger.log('[NapCat] [Framework] 二维码已更新, URL:', qrcodeUrl);
     };
 
@@ -146,9 +155,14 @@ export async function NCoreInitFramework (
         WebUiDataRuntime.setQQQuickLoginList(list.map((item) => item.uin.toString()));
         WebUiDataRuntime.setQQNewLoginList(list);
       }).catch(e => logger.logError('[NapCat] [Framework] 获取登录列表失败:', e));
+      if (!loginContext.isLogined) {
+        const requested = loginService.getQRCodePicture();
+        logger.logWarn('[NapCat] [Framework] 登录服务连接完成，正在获取二维码', { requested, msfStatus: loginService.getMsfStatus() });
+      }
     };
 
     loginListener.onQRCodeSessionUserScaned = () => {
+      WebUiDataRuntime.setQQLoginPhase('qrcode_scanned');
       logger.log('[NapCat] [Framework] 二维码已被扫描，等待确认...');
     };
 
@@ -194,11 +208,34 @@ export async function NCoreInitFramework (
   const oneBotAdapter = adapterManager.getOneBotAdapter();
   if (oneBotAdapter) {
     WebUiDataRuntime.setOneBotContext(oneBotAdapter);
+    if (WebUiDataRuntime.getQQLoginStatus()) {
+      WebUiDataRuntime.setQQLoginPhase('ready');
+    }
   }
 
   // 监听下线通知并同步到 WebUI（兜底保障，防止 WebUI 状态不同步）
-  loaderObject.core.event.on('KickedOffLine', () => {
+  let restartRequested = false;
+  loaderObject.core.event.on('KickedOffLine', (tips: string) => {
     WebUiDataRuntime.setQQLoginStatus(false);
+    WebUiDataRuntime.setQQLoginQrcodeURL('');
+    WebUiDataRuntime.setQQLoginError(tips);
+    WebUiDataRuntime.setQQLoginPhase('reconnecting');
+    if (restartRequested) return;
+    restartRequested = true;
+    setTimeout(() => {
+      WebUiDataRuntime.requestRestartProcess().then((restartResult) => {
+        logger.logWarn('[NapCat] [Framework] 账号被踢下线，正在重启 Worker 以重新创建 QQ 登录服务', restartResult);
+        if (!restartResult.result) {
+          restartRequested = false;
+          WebUiDataRuntime.setQQLoginPhase('offline');
+          WebUiDataRuntime.setQQLoginError(`${tips}\n登录服务重启失败：${restartResult.message}`);
+        }
+      }).catch((error) => {
+        restartRequested = false;
+        WebUiDataRuntime.setQQLoginPhase('offline');
+        WebUiDataRuntime.setQQLoginError(`${tips}\n登录服务重启失败：${(error as Error).message}`);
+      });
+    }, 3_500);
   });
 }
 
@@ -209,7 +246,22 @@ function registerWebUiLoginCallbacks (
 ) {
   // 刷新二维码
   WebUiDataRuntime.setRefreshQRCodeCallback(async () => {
-    loginService.getQRCodePicture();
+    loginContext.isLogined = false;
+    const msfStatus = loginService.getMsfStatus();
+    if (msfStatus === 2) {
+      WebUiDataRuntime.setQQLoginPhase('reconnecting');
+      const connected = loginService.connect();
+      logger.logWarn('[NapCat] [Framework] 登录服务离线，正在重连以获取二维码', { connected, msfStatus });
+      if (!connected) {
+        throw new Error('QQ 登录服务无法重新连接');
+      }
+      return;
+    }
+    const requested = loginService.getQRCodePicture();
+    logger.logWarn('[NapCat] [Framework] 请求刷新二维码', { requested, msfStatus });
+    if (!requested) {
+      throw new Error('QQ 未接受二维码刷新请求');
+    }
   });
 
   // 快速登录

--- a/packages/napcat-shell/base.ts
+++ b/packages/napcat-shell/base.ts
@@ -126,7 +126,7 @@ async function handleLogin (
   quickLoginUin: string | undefined,
   historyLoginList: LoginListItem[]
 ): Promise<SelfInfo> {
-  const context = { isLogined: false };
+  const context = { isLogined: false, loginFlowInitialized: false };
   let inner_resolve: (value: SelfInfo) => void;
   const selfInfo: Promise<SelfInfo> = new Promise((resolve) => {
     inner_resolve = resolve;
@@ -142,6 +142,14 @@ async function handleLogin (
   loginListener.onQRCodeLoginSucceed = async (loginResult) => {
     context.isLogined = true;
     WebUiDataRuntime.setQQLoginStatus(true);
+    WebUiDataRuntime.setQQLoginError('');
+    const oneBotContext = WebUiDataRuntime.getOneBotContext();
+    if (oneBotContext?.core?.selfInfo) {
+      oneBotContext.core.selfInfo.online = true;
+      WebUiDataRuntime.setQQLoginPhase('ready');
+    } else {
+      WebUiDataRuntime.setQQLoginPhase('initializing');
+    }
     inner_resolve({
       uid: loginResult.uid,
       uin: loginResult.uin,
@@ -149,14 +157,35 @@ async function handleLogin (
       online: true,
     });
   };
+  loginListener.onLoginDisConnected = () => {
+    context.isLogined = false;
+    WebUiDataRuntime.setQQLoginStatus(false);
+    WebUiDataRuntime.setQQLoginPhase('offline');
+    logger.logWarn('[Core] [Login] 登录服务已断开，将允许重新获取二维码');
+  };
+  loginListener.onLogoutSucceed = () => {
+    context.isLogined = false;
+    WebUiDataRuntime.setQQLoginStatus(false);
+    WebUiDataRuntime.setQQLoginPhase('offline');
+  };
   loginListener.onLoginConnected = () => {
-    waitForNetworkConnection(loginService, logger).then(() => {
-      handleLoginInner(context, logger, loginService, quickLoginUin, historyLoginList).then().catch(e => logger.logError(e));
-      loginListener.onLoginConnected = () => { };
-    });
+    waitForNetworkConnection(loginService, logger).then(async () => {
+      if (!context.loginFlowInitialized) {
+        context.loginFlowInitialized = true;
+        await handleLoginInner(context, logger, loginService, quickLoginUin, historyLoginList);
+        return;
+      }
+      if (!context.isLogined) {
+        WebUiDataRuntime.setQQLoginPhase('generating_qrcode');
+        const requested = loginService.getQRCodePicture();
+        logger.logWarn('[Core] [Login] 登录服务重连完成，正在获取二维码', { requested, msfStatus: loginService.getMsfStatus() });
+      }
+    }).catch(e => logger.logError(e));
   };
   loginListener.onQRCodeGetPicture = ({ pngBase64QrcodeData, qrcodeUrl }) => {
     WebUiDataRuntime.setQQLoginQrcodeURL(qrcodeUrl);
+    WebUiDataRuntime.setQQLoginError('');
+    WebUiDataRuntime.setQQLoginPhase('waiting_qrcode');
 
     const realBase64 = pngBase64QrcodeData.replace(/^data:image\/\w+;base64,/, '');
     const buffer = Buffer.from(realBase64, 'base64');
@@ -175,14 +204,20 @@ async function handleLogin (
     });
   };
 
+  loginListener.onQRCodeSessionUserScaned = () => {
+    WebUiDataRuntime.setQQLoginPhase('qrcode_scanned');
+    logger.log('[Core] [Login] 二维码已被扫描，等待确认...');
+  };
+
   loginListener.onQRCodeSessionFailed = (errType: number, errCode: number) => {
     if (!context.isLogined) {
       logger.logError('[Core] [Login] Login Error,ErrType: ', errType, ' ErrCode:', errCode);
       if (errType === 1 && errCode === 3) {
-        // 二维码过期刷新
+        // 仅二维码过期时自动请求下一张二维码。账号被踢下线等其他错误
+        // 需要由用户触发刷新，避免每两秒重复创建原生登录会话。
         WebUiDataRuntime.setQQLoginError('二维码已过期，请刷新');
+        loginService.getQRCodePicture();
       }
-      loginService.getQRCodePicture();
     }
   };
 
@@ -196,7 +231,7 @@ async function handleLogin (
   loginService.connect();
   return await selfInfo;
 }
-async function handleLoginInner (context: { isLogined: boolean; }, logger: LogWrapper, loginService: NodeIKernelLoginService, quickLoginUin: string | undefined, historyLoginList: LoginListItem[]) {
+async function handleLoginInner (context: { isLogined: boolean; loginFlowInitialized: boolean; }, logger: LogWrapper, loginService: NodeIKernelLoginService, quickLoginUin: string | undefined, historyLoginList: LoginListItem[]) {
   const resolveQuickPasswordMd5 = (): string | undefined => {
     const quickPasswordMd5 = process.env['NAPCAT_QUICK_PASSWORD_MD5']?.trim();
     if (quickPasswordMd5) {
@@ -217,7 +252,19 @@ async function handleLoginInner (context: { isLogined: boolean; }, logger: LogWr
 
   // 注册刷新二维码回调
   WebUiDataRuntime.setRefreshQRCodeCallback(async () => {
-    loginService.getQRCodePicture();
+    context.isLogined = false;
+    const msfStatus = loginService.getMsfStatus();
+    if (msfStatus === 2) {
+      // KickedOffLine 会在后台负责重启 Worker。这里不能重启：该回调由
+      // RefreshQRcode HTTP 请求触发，重启会中断正在等待响应的请求。
+      WebUiDataRuntime.setQQLoginPhase('reconnecting');
+      throw new Error('QQ_LOGIN_SERVICE_RESTARTING');
+    }
+    const requested = loginService.getQRCodePicture();
+    logger.logWarn('[Core] [Login] 请求刷新二维码', { requested, msfStatus });
+    if (!requested) {
+      throw new Error('QQ 未接受二维码刷新请求');
+    }
   });
 
   WebUiDataRuntime.setQuickLoginCall(async (uin: string) => {
@@ -793,9 +840,34 @@ export class NapCatShell {
     // }
 
     // 监听下线通知并同步到 WebUI
+    let restartRequested = false;
     this.core.event.on('KickedOffLine', (tips: string) => {
       WebUiDataRuntime.setQQLoginStatus(false);
+      // 被踢后的二维码已失效，绝不能继续交给页面展示或扫码。
+      WebUiDataRuntime.setQQLoginQrcodeURL('');
       WebUiDataRuntime.setQQLoginError(tips);
+      WebUiDataRuntime.setQQLoginPhase('reconnecting');
+
+      if (restartRequested) return;
+      restartRequested = true;
+      // 不从 RefreshQRcode 请求中重启 Worker；否则请求会在返回前被中断，
+      // 浏览器只能得到 ERR_EMPTY_RESPONSE。KickedOffLine 是独立事件，
+      // 在此异步调度可让前端先观察到“二维码已清空、正在恢复”的状态。
+      setTimeout(() => {
+        WebUiDataRuntime.requestRestartProcess().then((restartResult) => {
+          this.context.logger.logWarn('[Core] [Login] 账号被踢下线，正在重启 Worker 以重新创建 QQ 登录服务', restartResult);
+          if (!restartResult.result) {
+            restartRequested = false;
+            WebUiDataRuntime.setQQLoginPhase('offline');
+            WebUiDataRuntime.setQQLoginError(`${tips}\n登录服务重启失败：${restartResult.message}`);
+          }
+        }).catch((error) => {
+          restartRequested = false;
+          WebUiDataRuntime.setQQLoginPhase('offline');
+          WebUiDataRuntime.setQQLoginError(`${tips}\n登录服务重启失败：${(error as Error).message}`);
+        });
+      // 常规状态轮询为 3 秒；留出一个轮询周期，确保浏览器先清除旧二维码。
+      }, 3_500);
     });
     // 使用 NapCatAdapterManager 统一管理协议适配器
     const adapterManager = new NapCatAdapterManager(this.core, this.context, this.context.pathWrapper);
@@ -805,6 +877,9 @@ export class NapCatShell {
     const oneBotAdapter = adapterManager.getOneBotAdapter();
     if (oneBotAdapter) {
       WebUiDataRuntime.setOneBotContext(oneBotAdapter);
+      if (WebUiDataRuntime.getQQLoginStatus()) {
+        WebUiDataRuntime.setQQLoginPhase('ready');
+      }
     }
   }
 }

--- a/packages/napcat-webui-backend/src/api/QQLogin.ts
+++ b/packages/napcat-webui-backend/src/api/QQLogin.ts
@@ -94,13 +94,19 @@ export const QQCheckLoginStatusHandler: RequestHandler = async (_, res) => {
   const selfInfo = oneBotContext?.core?.selfInfo;
   const isOnline = selfInfo?.online;
   const qqLoginStatus = WebUiDataRuntime.getQQLoginStatus();
+  const loginPhase = WebUiDataRuntime.getQQLoginPhase();
   // 必须同时满足：已登录且在线（online 必须明确为 true）
+  // 登录状态以 QQ 登录成功和 Core 明确在线为准。loginPhase 用于展示进度，
+  // 不能作为跳转的额外门槛，否则 phase 事件延迟时会卡在扫码页。
   const isLogin = qqLoginStatus && isOnline === true;
   // 检测掉线状态：已登录但不在线
   const isOffline = qqLoginStatus && isOnline === false;
   const data = {
     isLogin,
     isOffline,
+    loginPhase,
+    qrLoginAccepted: qqLoginStatus && (loginPhase === 'qrcode_scanned' || loginPhase === 'initializing'),
+    coreReady: qqLoginStatus && isOnline === true,
     qrcodeurl: WebUiDataRuntime.getQQLoginQrcodeURL(),
     loginError: WebUiDataRuntime.getQQLoginError(),
   };
@@ -174,14 +180,25 @@ export const setAutoLoginAccountHandler: RequestHandler = async (req, res) => {
 
 // 刷新QQ登录二维码
 export const QQRefreshQRcodeHandler: RequestHandler = async (_, res) => {
-  // 判断是否已经登录
-  if (WebUiDataRuntime.getQQLoginStatus()) {
+  // 与 CheckLoginStatus 保持一致：运行时登录标记可能在账号下线后
+  // 尚未同步，但 core.selfInfo.online 已能反映实际在线状态。
+  const oneBotContext = WebUiDataRuntime.getOneBotContext();
+  const isOnline = oneBotContext?.core?.selfInfo?.online === true;
+  if (WebUiDataRuntime.getQQLoginStatus() && isOnline) {
     // 已经登录
     return sendError(res, 'QQ Is Logined');
   }
-  // 刷新二维码
-  await WebUiDataRuntime.refreshQRCode();
-  return sendSuccess(res, null);
+  // 被踢下线后，后台会从 KickedOffLine 事件异步重启 Worker。不要在这个
+  // HTTP 请求里再次触发刷新/重启，否则 Worker 退出会打断该响应。
+  if (WebUiDataRuntime.getQQLoginPhase() === 'reconnecting') {
+    return sendSuccess(res, { qrcodeurl: '', restarting: true });
+  }
+  try {
+    const qrcodeurl = await WebUiDataRuntime.refreshQRCode();
+    return sendSuccess(res, { qrcodeurl });
+  } catch (error) {
+    return sendError(res, `QRCode Refresh Error: ${(error as Error).message}`);
+  }
 };
 
 // 密码登录

--- a/packages/napcat-webui-backend/src/helper/Data.ts
+++ b/packages/napcat-webui-backend/src/helper/Data.ts
@@ -1,12 +1,13 @@
 import store from 'napcat-common/src/store';
 import { napCatVersion } from 'napcat-common/src/version';
-import { NapCatCoreWorkingEnv, type LoginRuntimeType } from '../types';
+import { NapCatCoreWorkingEnv, type LoginRuntimeType, type QQLoginPhase } from '../types';
 
 const LoginRuntime: LoginRuntimeType = {
   workingEnv: NapCatCoreWorkingEnv.Unknown,
   LoginCurrentTime: Date.now(),
   LoginCurrentRate: 0,
   QQLoginStatus: false, // 已实现 但太傻了 得去那边注册个回调刷新
+  QQLoginPhase: 'waiting_qrcode',
   QQQRCodeURL: '',
   QQLoginUin: '',
   QQLoginInfo: {
@@ -99,6 +100,14 @@ export const WebUiDataRuntime = {
 
   setQQLoginStatus (status: LoginRuntimeType['QQLoginStatus']): void {
     LoginRuntime.QQLoginStatus = status;
+  },
+
+  setQQLoginPhase (phase: QQLoginPhase): void {
+    LoginRuntime.QQLoginPhase = phase;
+  },
+
+  getQQLoginPhase (): QQLoginPhase {
+    return LoginRuntime.QQLoginPhase;
   },
 
   setQQLoginQrcodeURL (url: LoginRuntimeType['QQQRCodeURL']): void {
@@ -238,7 +247,23 @@ export const WebUiDataRuntime = {
   },
 
   refreshQRCode: async function () {
+    const previousQRCodeUrl = LoginRuntime.QQQRCodeURL;
     LoginRuntime.QQLoginError = '';
+    LoginRuntime.QQLoginPhase = 'generating_qrcode';
     await LoginRuntime.onRefreshQRCode();
+
+    const refreshTimeout = 10_000;
+    const deadline = Date.now() + refreshTimeout;
+    while (Date.now() < deadline) {
+      const qrcodeUrl = LoginRuntime.QQQRCodeURL;
+      if (qrcodeUrl && qrcodeUrl !== previousQRCodeUrl) {
+        LoginRuntime.QQLoginPhase = 'waiting_qrcode';
+        return qrcodeUrl;
+      }
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    LoginRuntime.QQLoginPhase = previousQRCodeUrl ? 'waiting_qrcode' : 'offline';
+    throw new Error('二维码刷新超时：QQ 登录服务未返回新的二维码');
   },
 };

--- a/packages/napcat-webui-backend/src/types/index.ts
+++ b/packages/napcat-webui-backend/src/types/index.ts
@@ -39,11 +39,22 @@ export enum NapCatCoreWorkingEnv {
   Shell = 1,
   Framework = 2,
 }
+
+export type QQLoginPhase =
+  | 'waiting_qrcode'
+  | 'generating_qrcode'
+  | 'qrcode_scanned'
+  | 'initializing'
+  | 'ready'
+  | 'offline'
+  | 'reconnecting';
+
 export interface LoginRuntimeType {
   workingEnv: NapCatCoreWorkingEnv;
   LoginCurrentTime: number;
   LoginCurrentRate: number;
   QQLoginStatus: boolean;
+  QQLoginPhase: QQLoginPhase;
   QQQRCodeURL: string;
   QQLoginUin: string;
   QQLoginInfo: SelfInfo;

--- a/packages/napcat-webui-frontend/src/components/qr_code_login.tsx
+++ b/packages/napcat-webui-frontend/src/components/qr_code_login.tsx
@@ -7,12 +7,33 @@ interface QrCodeLoginProps {
   qrcode: string;
   loginError?: string;
   onRefresh?: () => void;
+  isRefreshing?: boolean;
+  loginPhase?: string;
+  isRecoveringLoginService?: boolean;
 }
 
-const QrCodeLogin: React.FC<QrCodeLoginProps> = ({ qrcode, loginError, onRefresh }) => {
+const QrCodeLogin: React.FC<QrCodeLoginProps> = ({ qrcode, loginError, onRefresh, isRefreshing = false, loginPhase, isRecoveringLoginService = false }) => {
+  const transitionMessage = loginPhase === 'qrcode_scanned'
+    ? '二维码已扫描，等待手机确认…'
+    : loginPhase === 'initializing'
+      ? 'QQ 登录成功，正在启动 NapCat…'
+      : loginPhase === 'reconnecting' || isRecoveringLoginService
+        ? '正在重新连接 QQ 登录服务…'
+        : undefined;
   return (
     <div className='flex flex-col items-center'>
-      {loginError
+      {(isRefreshing || transitionMessage) && (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm'>
+          <div className='flex flex-col items-center gap-4 rounded-xl bg-content1 px-10 py-8 shadow-xl'>
+            <Spinner color='primary' size='lg' />
+            <div className='text-lg font-medium'>{transitionMessage || '正在刷新二维码…'}</div>
+            <div className='text-sm text-default-500'>
+              {transitionMessage ? '请不要关闭此页面，最长可能需要 3 分钟' : '正在等待新的二维码，最长 10 秒'}
+            </div>
+          </div>
+        </div>
+      )}
+      {loginError && !qrcode && !isRecoveringLoginService
         ? (
           <div className='flex flex-col items-center py-4'>
             <div className='w-full flex justify-center mb-6'>
@@ -34,6 +55,8 @@ const QrCodeLogin: React.FC<QrCodeLoginProps> = ({ qrcode, loginError, onRefresh
                 size='lg'
                 startContent={<IoRefresh />}
                 onPress={onRefresh}
+                isLoading={isRefreshing}
+                isDisabled={isRefreshing}
               >
                 重新获取二维码
               </Button>
@@ -42,13 +65,18 @@ const QrCodeLogin: React.FC<QrCodeLoginProps> = ({ qrcode, loginError, onRefresh
         )
         : (
           <>
+            {loginError && (
+              <div className='mb-4 w-full max-w-[360px] rounded-lg bg-warning-50 px-4 py-3 text-center text-sm text-warning-700 dark:bg-warning-50/20 dark:text-warning-300'>
+                {loginError}
+              </div>
+            )}
             <div className='bg-white p-2 rounded-md w-fit mx-auto relative overflow-hidden'>
               {!qrcode && (
                 <div className='absolute left-0 top-0 right-0 bottom-0 bg-white dark:bg-zinc-900 bg-opacity-90 backdrop-blur-sm flex items-center justify-center z-10'>
                   <Spinner color='primary' />
                 </div>
               )}
-              <QRCodeSVG size={180} value={qrcode || ' '} />
+              <QRCodeSVG key={qrcode} size={180} value={qrcode || ' '} />
             </div>
             <div className='mt-5 text-center text-default-500 text-sm'>请使用QQ或者TIM扫描上方二维码</div>
             {onRefresh && qrcode && (
@@ -59,6 +87,8 @@ const QrCodeLogin: React.FC<QrCodeLoginProps> = ({ qrcode, loginError, onRefresh
                 size='sm'
                 startContent={<IoRefresh />}
                 onPress={onRefresh}
+                isLoading={isRefreshing}
+                isDisabled={isRefreshing}
               >
                 刷新二维码
               </Button>

--- a/packages/napcat-webui-frontend/src/controllers/qq_manager.ts
+++ b/packages/napcat-webui-frontend/src/controllers/qq_manager.ts
@@ -32,14 +32,23 @@ export default class QQManager {
 
   public static async checkQQLoginStatusWithQrcode () {
     const data = await serverRequest.post<
-      ServerResponse<{ qrcodeurl: string; isLogin: boolean; isOffline?: boolean; loginError?: string; }>
+      ServerResponse<{
+        qrcodeurl: string;
+        isLogin: boolean;
+        isOffline?: boolean;
+        loginError?: string;
+        loginPhase?: 'waiting_qrcode' | 'generating_qrcode' | 'qrcode_scanned' | 'initializing' | 'ready' | 'offline' | 'reconnecting';
+        qrLoginAccepted?: boolean;
+        coreReady?: boolean;
+      }>
     >('/QQLogin/CheckLoginStatus');
 
     return data.data.data;
   }
 
   public static async refreshQRCode () {
-    await serverRequest.post<ServerResponse<null>>('/QQLogin/RefreshQRcode');
+    const data = await serverRequest.post<ServerResponse<{ qrcodeurl: string; restarting?: boolean; }>>('/QQLogin/RefreshQRcode');
+    return data.data.data;
   }
 
   public static async getQQLoginQrcode () {

--- a/packages/napcat-webui-frontend/src/pages/qq_login.tsx
+++ b/packages/napcat-webui-frontend/src/pages/qq_login.tsx
@@ -53,6 +53,11 @@ export default function QQLoginPage () {
   const [uinValue, setUinValue] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [qrcode, setQrcode] = useState<string>('');
+  const [loginPhase, setLoginPhase] = useState<string>('waiting_qrcode');
+  const [isRecoveringLoginService, setIsRecoveringLoginService] = useState(false);
+  const qrcodeRef = useRef<string>('');
+  const qrcodeRequestVersionRef = useRef(0);
+  const isRefreshingQRCodeRef = useRef(false);
   const [loginError, setLoginError] = useState<string>('');
   const lastErrorRef = useRef<string>('');
   const [qqList, setQQList] = useState<(QQItem | LoginListItem)[]>([]);
@@ -199,9 +204,14 @@ export default function QQLoginPage () {
   };
 
   const onUpdateQrCode = async () => {
+    const requestVersion = qrcodeRequestVersionRef.current;
     if (firstLoad.current) setIsLoading(true);
     try {
       const data = await QQManager.checkQQLoginStatusWithQrcode();
+      setLoginPhase(data.loginPhase || (data.isLogin ? 'ready' : 'waiting_qrcode'));
+      if (data.loginPhase === 'reconnecting') {
+        setIsRecoveringLoginService(true);
+      }
 
       if (firstLoad.current) {
         setIsLoading(false);
@@ -211,17 +221,26 @@ export default function QQLoginPage () {
         toast.success('QQ登录成功');
         navigate('/', { replace: true });
       } else {
-        setQrcode(data.qrcodeurl);
+        // 刷新二维码是一个需要等待结果的操作。忽略在它开始前发出的
+        // 轮询响应，避免旧 URL 在刷新完成后覆盖刚拿到的新二维码。
+        if (requestVersion === qrcodeRequestVersionRef.current && !isRefreshingQRCodeRef.current) {
+          qrcodeRef.current = data.qrcodeurl;
+          setQrcode(data.qrcodeurl);
+          if (data.qrcodeurl) {
+            setIsRecoveringLoginService(false);
+          }
+        }
         if (data.loginError && data.loginError !== lastErrorRef.current) {
           lastErrorRef.current = data.loginError;
           setLoginError(data.loginError);
           const friendlyMsg = parseLoginError(data.loginError);
 
-          // 仅在扫码登录 Tab 下才弹窗，或者错误不是"二维码已过期"
-          // 如果是 "二维码已过期"，且不在 qrcode tab，则不弹窗
+          // 被踢下线时页面会自动进入登录服务恢复流程。它不是可由用户
+          // 处理的登录表单错误，也不应弹出对话框遮住恢复状态。
+          const isRecovering = data.loginPhase === 'reconnecting' || isRecoveringLoginService;
           const isQrCodeExpired = friendlyMsg.includes('二维码') && (friendlyMsg.includes('过期') || friendlyMsg.includes('失效'));
 
-          if (!isQrCodeExpired || activeTab === 'qrcode') {
+          if (!isRecovering && (!isQrCodeExpired || activeTab === 'qrcode')) {
             dialog.alert({
               title: '登录失败',
               content: friendlyMsg,
@@ -235,8 +254,11 @@ export default function QQLoginPage () {
       }
     } catch (error) {
       const msg = (error as Error).message;
-
-      toast.error(`获取二维码失败: ${msg}`);
+      // Worker 重启时，旧连接被关闭是预期现象。恢复状态持续轮询即可，
+      // 不要把 ERR_EMPTY_RESPONSE 作为用户可操作的错误反复弹出。
+      if (!isRecoveringLoginService) {
+        toast.error(`获取二维码失败: ${msg}`);
+      }
     }
   };
 
@@ -271,29 +293,74 @@ export default function QQLoginPage () {
   };
 
   const onRefreshQRCode = async () => {
+    if (isRecoveringLoginService || loginPhase === 'reconnecting') {
+      toast('QQ 登录服务正在恢复，请等待新的二维码…', { icon: '⏳' });
+      return;
+    }
+    if (isRefreshingQRCodeRef.current) {
+      return;
+    }
+    qrcodeRequestVersionRef.current += 1;
+    isRefreshingQRCodeRef.current = true;
+    setIsRefreshingQRCode(true);
     try {
       lastErrorRef.current = '';
       setLoginError('');
-      await QQManager.refreshQRCode();
-      toast.success('已发送刷新请求');
+      const { qrcodeurl, restarting } = await QQManager.refreshQRCode();
+      if (restarting) {
+        setIsRecoveringLoginService(true);
+        setLoginPhase('reconnecting');
+        return;
+      }
+      if (!qrcodeurl || qrcodeurl === qrcodeRef.current) {
+        throw new Error('未获取到新的二维码');
+      }
+      qrcodeRef.current = qrcodeurl;
+      setQrcode(qrcodeurl);
+      toast.success('二维码已刷新');
     } catch (error) {
       const msg = (error as Error).message;
-      toast.error(`刷新二维码失败: ${msg}`);
+      if (msg.includes('QQ_LOGIN_SERVICE_RESTARTING')) {
+        setIsRecoveringLoginService(true);
+        setLoginPhase('reconnecting');
+        toast('QQ 登录服务正在重启，正在生成新的二维码…', { icon: '⏳' });
+      } else if (msg.includes('二维码刷新超时')) {
+        toast.error('未能取得新的二维码，请稍后重试');
+      } else {
+        toast.error(`刷新二维码失败: ${msg}`);
+      }
+    } finally {
+      qrcodeRequestVersionRef.current += 1;
+      isRefreshingQRCodeRef.current = false;
+      setIsRefreshingQRCode(false);
     }
   };
 
   const [showGUIDManager, setShowGUIDManager] = useState(false);
+  const [isRefreshingQRCode, setIsRefreshingQRCode] = useState(false);
 
   useEffect(() => {
+    const isLoginTransitioning = loginPhase === 'qrcode_scanned' || loginPhase === 'initializing' || loginPhase === 'reconnecting' || isRecoveringLoginService;
+    const pollInterval = isRefreshingQRCode || isLoginTransitioning ? 500 : 3000;
     const timer = setInterval(() => {
       onUpdateQrCode();
-    }, 3000);
+    }, pollInterval);
 
     onUpdateQrCode();
     onUpdateQQList();
 
     return () => clearInterval(timer);
-  }, []);
+  }, [isRefreshingQRCode, loginPhase, isRecoveringLoginService]);
+
+  useEffect(() => {
+    if (!isRecoveringLoginService) return;
+    const timer = setTimeout(() => {
+      setIsRecoveringLoginService(false);
+      setLoginPhase('offline');
+      setLoginError('QQ 登录服务恢复超时，请稍后重试');
+    }, 180_000);
+    return () => clearTimeout(timer);
+  }, [isRecoveringLoginService]);
 
   return (
     <>
@@ -369,6 +436,9 @@ export default function QQLoginPage () {
                     loginError={parseLoginError(loginError)}
                     qrcode={qrcode}
                     onRefresh={onRefreshQRCode}
+                    isRefreshing={isRefreshingQRCode}
+                    loginPhase={loginPhase}
+                    isRecoveringLoginService={isRecoveringLoginService}
                   />
                 </Tab>
               </Tabs>


### PR DESCRIPTION
## 问题

QQ 账号被强制下线后，WebUI 仍可能显示已失效的旧二维码；点击刷新二维码时，原生 QQ 登录服务有时无法重新生成二维码。 #1962  #2027


此前若由刷新接口直接重启 Worker，会中断正在执行的 HTTP 请求，导致前端出现 `ERR_EMPTY_RESPONSE`、刷新失败或持续加载；部分情况下即使已经完成登录，页面也可能仍停留在扫码登录界面。

## 修改内容

- 为 QQ 登录流程补充二维码等待、已扫码、初始化完成、重连中等状态。
- 刷新二维码接口等待 QQ 登录服务实际返回新的二维码，再向前端返回结果。
- 刷新期间提高状态轮询频率，并阻止重复刷新请求覆盖新二维码。
- QQ 登录成功后同时结合运行时登录状态与 Core 在线状态判断，避免已登录后仍停留在扫码界面。
- 收到 `KickedOffLine` 后立即清空旧二维码，避免继续展示或扫描已失效二维码。
- 被踢下线后由独立事件异步重启 QQ 登录服务，而非在刷新二维码请求中重启，避免中断该请求。
- 前端在登录服务恢复期间显示“正在重新连接 QQ 登录服务”，静默重试状态请求；收到新二维码后自动恢复扫码界面。
- 恢复期间不再弹出阻塞性的“登录失败”对话框，也不会将预期的连接中断显示为刷新错误。
- 登录服务恢复超时后才提示用户重试。

## 验证

- 所有本次变更的 TypeScript 文件 ESLint 检查通过。
- Shell 生产构建通过。
- 在本地 `mlikiowa/napcat-docker:latest` 测试容器中验证：
  - 强制下线后旧二维码会被清空；
  - 页面进入 QQ 登录服务恢复状态；
  - 服务重启后能够重新显示新的二维码；
  - 扫码登录完成后页面能够跳转。